### PR TITLE
added support to oobabooga/text-generation-webui - fixed base.py to return error when "no_code"

### DIFF
--- a/pandasai/llm/base.py
+++ b/pandasai/llm/base.py
@@ -88,10 +88,9 @@ class LLM:
         match = re.search(rf"{START_CODE_TAG}(.*){END_CODE_TAG}", code, re.DOTALL)
         if match:
             code = match.group(1).strip()
-        code = self._polish_code(code)
         if not self._is_python_code(code):
             raise NoCodeFoundError("No code found in the response")
-
+        code = self._polish_code(code)
         return code
 
     def call(self, instruction: str, value: str) -> None:

--- a/pandasai/llm/text_gen_webui.py
+++ b/pandasai/llm/text_gen_webui.py
@@ -1,0 +1,38 @@
+"""TextGenWebui LLM"""
+
+from typing import Optional
+
+from .base import LLM
+import requests
+
+
+class TextGenWebuiLLM(LLM):
+    """TextGenWebui LLM"""
+
+    _output: str = 'print("Hello world")'
+    api_url: str = (
+        "http://localhost:5000/api/v1/generate"
+    )
+
+    def __init__(self, api_url: Optional[str] = None):
+        if api_url is not None:
+            self.api_url = api_url
+
+    def query(self, payload):
+        
+        response = requests.post(
+            self.api_url, json=payload, timeout=60
+        )
+        return response.json()
+
+
+    def call(self, instruction: str, value: str) -> str:
+
+        output = self.query(
+            {"prompt": "<|prompter|>" + instruction + value + "<|endoftext|>"}
+        )
+        return output["results"][0]["text"]
+    
+    @property
+    def type(self) -> str:
+        return "text-gen-webui"


### PR DESCRIPTION
Added support to `oobabooga/text-generation-webui` through API.

You can test starting text-generation-webui with:
`python server.py --api --listen --no-stream --model-menu` 

and the following code:

```import pandas as pd
from pandasai import PandasAI

# Sample DataFrame
df = pd.DataFrame({
    "country": ["United States", "United Kingdom", "France", "Germany", "Italy", "Spain", "Canada", "Australia", "Japan", "China"],
    "gdp": [19294482071552, 2891615567872, 2411255037952, 3435817336832, 1745433788416, 1181205135360, 1607402389504, 1490967855104, 4380756541440, 14631844184064],
    "happiness_index": [6.94, 7.16, 6.66, 7.07, 6.38, 6.4, 7.23, 7.22, 5.87, 5.12]
})

from pandasai.llm.text_gen_webui import TextGenWebuiLLM
llm = TextGenWebuiLLM()
pandas_ai = PandasAI(llm, verbose=True)
pandas_ai.run(df, prompt='Which are the 5 happiest countries?')
```