### PR TITLE
docs: refer to pandas-ai api in langchain-serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ llm = Starcoder(api_token="YOUR_HF_API_KEY")
 
 ## pandas-ai as an API
 
-You can deploy pandas-ai as an API using [langchain-serve](https://github.com/jina-ai/langchain-serve#panda_face-pandas-ai-as-a-service), which provides REST/Websocket APIs and a CLI playground, making it easy to interact with your data in a conversational manner.
+You can deploy pandas-ai as an (experimental) API using [langchain-serve](https://github.com/jina-ai/langchain-serve#panda_face-pandas-ai-as-a-service), which provides REST/Websocket APIs and a CLI playground, making it easy to interact with your data in a conversational manner.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ llm = OpenAI(api_token="YOUR_OPENAI_API_KEY")
 llm = Starcoder(api_token="YOUR_HF_API_KEY")
 ```
 
+## pandas-ai as an API
+
+You can deploy pandas-ai as an API using [langchain-serve](https://github.com/jina-ai/langchain-serve#panda_face-pandas-ai-as-a-service), which provides REST/Websocket APIs and a CLI playground, making it easy to interact with your data in a conversational manner.
+
+
 ## License
 
 PandasAI is licensed under the MIT License. See the LICENSE file for more details.


### PR DESCRIPTION
Closed https://github.com/gventuri/pandas-ai/pull/48 after a discussion with @gventuri and implemented the API layer in [langchain-serve](https://github.com/jina-ai/langchain-serve#panda_face-pandas-ai-as-a-service). This PR adds a link in the readme to the experimental APIs on lc-serve.