### PR TITLE
move pylint config from `.pylintrc` file to `pyproject.toml`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,0 @@
-[MAIN]
-ignore=test_*

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
-[MASTER]
+[MAIN]
 ignore=test_*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ isort = "^5.12.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pylint]
+ignore = "tests_*"


### PR DESCRIPTION
This PR closes #68. 

The branch name in the `.pylintrc` file was `MASTER`, that's why the linting in tests was not ignored. 

And I took this opportunity to move the `.pylintrc` config to `pyproject.toml`. 