### PR TITLE
Replace `run` with `__call__` in examples

### DIFF
--- a/examples/from_csv.py
+++ b/examples/from_csv.py
@@ -9,6 +9,6 @@ df = pd.read_csv("examples/data/Loan payments data.csv")
 
 llm = OpenAI()
 pandas_ai = PandasAI(llm, verbose=True)
-response = pandas_ai.run(df, "How many loans are from men and have been paid off?")
+response = pandas_ai(df, "How many loans are from men and have been paid off?")
 print(response)
 # Output: 247 loans have been paid off by men.

--- a/examples/from_dataframe.py
+++ b/examples/from_dataframe.py
@@ -11,6 +11,6 @@ df = pd.DataFrame(dataframe)
 
 llm = OpenAI()
 pandas_ai = PandasAI(llm, verbose=True, conversational=False)
-response = pandas_ai.run(df, "Calculate the sum of the gdp of north american countries")
+response = pandas_ai(df, "Calculate the sum of the gdp of north american countries")
 print(response)
 # Output: 20901884461056

--- a/examples/show_chart.py
+++ b/examples/show_chart.py
@@ -11,7 +11,7 @@ df = pd.DataFrame(dataframe)
 
 llm = OpenAI()
 pandas_ai = PandasAI(llm)
-response = pandas_ai.run(
+response = pandas_ai(
     df,
     "Plot the histogram of countries showing for each the gpd, using different colors for each bar",
 )

--- a/examples/with_privacy_enforced.py
+++ b/examples/with_privacy_enforced.py
@@ -11,7 +11,7 @@ df = pd.DataFrame(dataframe)
 
 llm = OpenAI()
 pandas_ai = PandasAI(llm, verbose=True, conversational=False, enforce_privacy=True)
-response = pandas_ai.run(
+response = pandas_ai(
     df,
     "Calculate the sum of the gdp of north american countries",
 )


### PR DESCRIPTION
This is just a left over from yesterday's PR. I replaced `run` with the functional operator in the README forgetting to do that in the examples. 
