### PR TITLE
Update pre-commit-config entry for pytest check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry: pytest
+        entry: poetry run pytest
         language: system
         pass_filenames: false
         always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Make sure that the linter does not report any errors or warnings before submitti
 We use `pytest` to test our code. You can run the tests by running the following command:
 
 ```bash
-pytest
+poetry run pytest
 ```
 
 Make sure that all tests pass before submitting a pull request.

--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -157,12 +157,11 @@ Code generated:
             use_error_correction_framework,
         )
 
-    def is_unsafe_import(self, node: ast.stmt) -> str:
+    def is_unsafe_import(self, node: ast.stmt) -> bool:
         """Remove non-whitelisted imports from the code to prevent malicious code execution"""
 
-        return (
-            isinstance(node, (ast.Import, ast.ImportFrom))
-            and any(alias.name not in WHITELISTED_LIBRARIES for alias in node.names)
+        return isinstance(node, (ast.Import, ast.ImportFrom)) and any(
+            alias.name not in WHITELISTED_LIBRARIES for alias in node.names
         )
 
     def is_df_overwrite(self, node: ast.stmt) -> str:
@@ -182,9 +181,7 @@ Code generated:
         new_body = [
             node
             for node in tree.body
-            if not (
-                self.is_unsafe_import(node) or self.is_df_overwrite(node)
-            )
+            if not (self.is_unsafe_import(node) or self.is_df_overwrite(node))
         ]
 
         new_tree = ast.Module(body=new_body)

--- a/pandasai/helpers/notebook.py
+++ b/pandasai/helpers/notebook.py
@@ -17,9 +17,7 @@ class Notebook:
         try:
             if "IPKernelApp" not in get_ipython().config:
                 return False
-        except ImportError:
-            return False
-        except AttributeError:
+        except (ImportError, AttributeError):
             return False
         return True
 

--- a/pandasai/llm/base.py
+++ b/pandasai/llm/base.py
@@ -15,6 +15,7 @@ from ..exceptions import (
     MethodNotImplementedError,
     NoCodeFoundError,
 )
+from ..prompts.base import Prompt
 
 
 class LLM:
@@ -91,12 +92,12 @@ class LLM:
         return code
 
     @abstractmethod
-    def call(self, instruction: str, value: str, suffix: str = "") -> str:
+    def call(self, instruction: Prompt, value: str, suffix: str = "") -> str:
         """
         Execute the LLM with given prompt.
 
         Args:
-            instruction (str): Prompt
+            instruction (Prompt): Prompt
             value (str): Value
             suffix (str, optional): Suffix. Defaults to "".
 
@@ -105,7 +106,7 @@ class LLM:
         """
         raise MethodNotImplementedError("Call method has not been implemented")
 
-    def generate_code(self, instruction: str, prompt: str) -> str:
+    def generate_code(self, instruction: Prompt, prompt: str) -> str:
         """
         Generate the code based on the instruction and the given prompt.
 
@@ -223,7 +224,7 @@ class HuggingFaceLLM(LLM):
 
         return response.json()[0]["generated_text"]
 
-    def call(self, instruction: str, value: str, suffix: str = "") -> str:
+    def call(self, instruction: Prompt, value: str, suffix: str = "") -> str:
         """Call the LLM"""
 
         payload = instruction + value + suffix
@@ -294,7 +295,7 @@ class BaseGoogle(LLM):
         """
         raise MethodNotImplementedError("method has not been implemented")
 
-    def call(self, instruction: str, value: str, suffix: str = "") -> str:
+    def call(self, instruction: Prompt, value: str, suffix: str = "") -> str:
         """
         Call the Google LLM.
 

--- a/pandasai/llm/fake.py
+++ b/pandasai/llm/fake.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 
+from ..prompts.base import Prompt
 from .base import LLM
 
 
@@ -14,7 +15,7 @@ class FakeLLM(LLM):
         if output is not None:
             self._output = output
 
-    def call(self, instruction: str, value: str, suffix: str = "") -> str:
+    def call(self, instruction: Prompt, value: str, suffix: str = "") -> str:
         self.last_prompt = str(instruction) + str(value) + suffix
         return self._output
 

--- a/pandasai/llm/openai.py
+++ b/pandasai/llm/openai.py
@@ -7,6 +7,7 @@ import openai
 from dotenv import load_dotenv
 
 from ..exceptions import APIKeyNotFoundError, UnsupportedOpenAIModelError
+from ..prompts.base import Prompt
 from .base import BaseOpenAI
 
 load_dotenv()
@@ -47,12 +48,12 @@ class OpenAI(BaseOpenAI):
             "model": self.model,
         }
 
-    def call(self, instruction: str, value: str, suffix: str = "") -> str:
+    def call(self, instruction: Prompt, value: str, suffix: str = "") -> str:
         """
         Call the OpenAI LLM.
 
         Args:
-            instruction (str): Instruction to pass
+            instruction (Prompt): Instruction to pass
             value (str): Value to pass
             suffix (str): Suffix to pass
 


### PR DESCRIPTION
Update CONTRIBUTING.md for running tests: pytest -> poetry run pytest
Fix typehints

For many, tests might fail necessarily when they run `pytest`,  `poetry run pytest` will ensure the right environment and dependencies are used and will avoid version mismatches.
Updated the command in CONTRIBUTING.md and pre-commit-config.
Fix some type hints mismatch after this [commit](https://github.com/gventuri/pandas-ai/commit/6862977169a3416ead856870d595eb21bb6a57d0)


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
