### PR TITLE
fix: pypi upload repo url

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
           ignore_dev_requirements: "yes"
-          repository_url: https://upload.pypi.org/
+          repository_url: https://upload.pypi.org/legacy/
           repository_name: pandasai


### PR DESCRIPTION
- [ ] closes #202
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).

As mentioned in the pypi org [documentation](https://packaging.python.org/en/latest/guides/migrating-to-pypi-org/), the repository URL should be `https://upload.pypi.org/legacy/`
