### PR TITLE
fix: save charts dir path on unix

### DIFF
--- a/pandasai/helpers/save_chart.py
+++ b/pandasai/helpers/save_chart.py
@@ -44,7 +44,7 @@ def add_save_chart(code: str) -> str:
 
     # define chart save directory
     project_root = dirname(dirname(dirname(__file__)))
-    chart_save_dir = os.path.join(project_root, f"exports\\charts\\{date}")
+    chart_save_dir = os.path.join(project_root, "exports", "charts", date)
     if not os.path.exists(chart_save_dir):
         os.makedirs(chart_save_dir)
 


### PR DESCRIPTION
- [ ] closes #212
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).

The issue is due to the file separator because on windows, the separator is a backslash `\`, while on Unix-based systems it is a forward slash `/`