### PR TITLE
fix: remove matplotlib from whitelisted libraries

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -35,6 +35,7 @@ Example:
 import ast
 import io
 import re
+import sys
 from contextlib import redirect_stdout
 from typing import Optional
 
@@ -43,6 +44,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from .constants import (
+    ENVIRONMENT_DEFAULTS,
     WHITELISTED_BUILTINS,
     WHITELISTED_LIBRARIES,
     WHITELISTED_OPTIONAL_LIBRARIES,
@@ -323,12 +325,15 @@ class PandasAI:
 
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             for alias in node.names:
-                if alias.name in WHITELISTED_BUILTINS:
+                if (
+                    alias.name in WHITELISTED_BUILTINS
+                    or alias.name in ENVIRONMENT_DEFAULTS
+                ):
                     return True
                 if alias.name in WHITELISTED_OPTIONAL_LIBRARIES:
                     import_optional_dependency(alias.name)
                     continue
-                if alias.name not in WHITELISTED_LIBRARIES:
+                if alias.name.split(".")[0] not in WHITELISTED_LIBRARIES:
                     raise BadImportError(alias.name)
 
         return False
@@ -412,8 +417,10 @@ Code running:
         )
 
         environment: dict = {
-            "pd": pd,
-            "plt": plt,
+            **{
+                alias: sys.modules[library]
+                for library, alias in ENVIRONMENT_DEFAULTS.items()
+            },
             "__builtins__": {
                 **{builtin: __builtins__[builtin] for builtin in WHITELISTED_BUILTINS},
             },

--- a/pandasai/constants.py
+++ b/pandasai/constants.py
@@ -7,10 +7,20 @@ It includes Start & End Code tags, Whitelisted Python Packages and While List Bu
 
 START_CODE_TAG = "<startCode>"
 END_CODE_TAG = "<endCode>"
+
+# List of Python packages that are whitelisted for import in generated code
+#   and are installed by default.
 WHITELISTED_LIBRARIES = [
     "numpy",
-    "matplotlib",
 ]
+
+# List of Python packages that are added to the environment by default.
+ENVIRONMENT_DEFAULTS = {
+    "pandas": "pd",
+    "matplotlib.pyplot": "plt",
+}
+
+# List of Python builtin libraries that are added to the environment by default.
 WHITELISTED_BUILTINS = [
     "abs",
     "all",
@@ -76,6 +86,9 @@ WHITELISTED_BUILTINS = [
     "vars",
     "zip",
 ]
+
+# List of Python packages that are whitelisted for import in generated code
+#   but are not installed by default.
 WHITELISTED_OPTIONAL_LIBRARIES = [
     "sklearn",
     "statsmodels",

--- a/tests/test_pandasai.py
+++ b/tests/test_pandasai.py
@@ -251,6 +251,15 @@ print(set([1, 2, 3]))
         assert pandasai.run_code(builtins_code, pd.DataFrame()) == {1, 2, 3}
         assert pandasai.last_run_code == "print(set([1, 2, 3]))"
 
+    def test_clean_code_remove_environment_defaults(self, pandasai):
+        pandas_code = """
+import pandas as pd
+print(df.size)
+"""
+        pandasai._llm._output = pandas_code
+        pandasai.run_code(pandas_code, pd.DataFrame())
+        assert pandasai.last_run_code == "print(df.size)"
+
     def test_clean_code_keep_whitelist(self, pandasai):
         safe_code = """
 import numpy as np


### PR DESCRIPTION
`matplotlib` is added to the environment passed to `exec()`, it should not also be imported in the run code.
Remove `matplotlib` from `WHITELISTED_LIBRARIES`, so imports are removed from the generated code.
Add ENVIRONMENT_DEFAULTS variable to consolidate logic.

- [x] closes #224 
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
- [x] Integration test.
