### PR TITLE
fix: replace path string with os.path.join

### DIFF
--- a/pandasai/helpers/save_chart.py
+++ b/pandasai/helpers/save_chart.py
@@ -91,9 +91,8 @@ def add_save_chart(code: str) -> str:
             if show_count > 1:
                 filename += f"_{chr(counter)}"
                 counter += 1
-            new_body.append(
-                ast.parse(f"plt.savefig(r'{chart_save_dir}\\{filename}.png')")
-            )
+            chart_save_path = os.path.join(chart_save_dir, filename + ".png")
+            new_body.append(ast.parse(f"plt.savefig(r'{chart_save_path}')"))
         new_body.append(node)
 
     new_body.append(ast.parse(f"print(r'Charts saved to: {chart_save_dir}')"))


### PR DESCRIPTION
Replace hardcoded, Windows based, file path with a call to `os.path.join`. This way the path is valid on Unix machines as well.

- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
- [x] Integration test on Windows machine
- [ ] Integration test on Unix machine

Note: I don't have easy access to a Unix environment. If someone wouldn't mind doublechecking that would be helpful.
