### PR TITLE
test: remove private method assertions

### DIFF
--- a/pandasai/llm/base.py
+++ b/pandasai/llm/base.py
@@ -386,7 +386,7 @@ class BaseGoogle(LLM):
         Call the Google LLM.
 
         Args:
-            instruction (str): Instruction to pass
+            instruction (object): Instruction to pass
             value (str): Value to pass
             suffix (str): Suffix to pass
 

--- a/tests/helpers/test_anonymizer.py
+++ b/tests/helpers/test_anonymizer.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 import pytest
 
 from pandasai.helpers.anonymizer import *

--- a/tests/helpers/test_cache.py
+++ b/tests/helpers/test_cache.py
@@ -15,3 +15,14 @@ class TestCache:
         assert cache.get("key") is None
 
         cache.destroy()
+
+    def test_read_cache(self):
+        cache_filename = f"cache_{uuid.uuid4().hex}"
+        cache = Cache(filename=cache_filename)
+        cache.set("key", "value")
+        cache.close()
+
+        cache = Cache(filename=cache_filename)
+        assert cache.get("key") == "value"
+
+        cache.destroy()

--- a/tests/llms/test_base_hf.py
+++ b/tests/llms/test_base_hf.py
@@ -1,4 +1,4 @@
-"""Unit tests for the base huggignface LLM class"""
+"""Unit tests for the base huggingface LLM class"""
 
 import pytest
 import requests
@@ -13,6 +13,13 @@ class TestBaseHfLLM:
     @pytest.fixture
     def api_response(self):
         return [{"generated_text": "Some text"}]
+
+    @pytest.fixture
+    def prompt(self):
+        class MockPrompt(Prompt):
+            text: str = "instruction"
+
+        return MockPrompt()
 
     def test_type(self):
         assert HuggingFaceLLM().type == "huggingface-llm"
@@ -44,13 +51,13 @@ class TestBaseHfLLM:
         # Check that the result is correct
         assert result == api_response[0]["generated_text"]
 
-    def test_call(self, mocker):
+    def test_call(self, mocker, prompt):
         huggingface = HuggingFaceLLM()
         huggingface.api_token = "test_token"
 
         mocker.patch.object(huggingface, "call", return_value="Generated text")
 
-        result = huggingface.call("instruction", "value", "suffix")
+        result = huggingface.call(prompt, "value", "suffix")
         assert result == "Generated text"
 
     def test_call_removes_original_prompt(self, mocker):

--- a/tests/llms/test_base_llm.py
+++ b/tests/llms/test_base_llm.py
@@ -20,6 +20,8 @@ class TestBaseLLM:
         assert LLM()._polish_code(code) == "print('Hello World')"
         code = "`print('Hello World')`"
         assert LLM()._polish_code(code) == "print('Hello World')"
+        code = "print('Hello World')"
+        assert LLM()._polish_code(code) == "print('Hello World')"
 
     def test_is_python_code(self):
         code = "python print('Hello World')"
@@ -63,6 +65,17 @@ print('Hello World')
 
 ```py
 print('Hello World')
+```
+"""
+
+        assert LLM()._extract_code(code) == "print('Hello World')"
+
+        code = """Sure, here is your code:
+
+<startCode>
+print('Hello World')
+<endCode>
+
 ```
 """
 

--- a/tests/llms/test_base_llm.py
+++ b/tests/llms/test_base_llm.py
@@ -20,7 +20,6 @@ class TestBaseLLM:
         assert LLM()._polish_code(code) == "print('Hello World')"
         code = "`print('Hello World')`"
         assert LLM()._polish_code(code) == "print('Hello World')"
-        code = "print('Hello World')"
 
     def test_is_python_code(self):
         code = "python print('Hello World')"
@@ -68,11 +67,3 @@ print('Hello World')
 """
 
         assert LLM()._extract_code(code) == "print('Hello World')"
-        code = """Sure, here is your code:
-
-<startCode>
-print('Hello World')
-<endCode>
-
-```
-"""

--- a/tests/llms/test_starcoder.py
+++ b/tests/llms/test_starcoder.py
@@ -12,12 +12,6 @@ class TestStarcoderLLM:
     def test_type(self):
         assert Starcoder(api_token="test").type == "starcoder"
 
-    def test_api_url(self):
-        assert (
-            Starcoder(api_token="test")._api_url
-            == "https://api-inference.huggingface.co/models/bigcode/starcoder"
-        )
-
     def test_init(self):
         with pytest.raises(APIKeyNotFoundError):
             Starcoder()

--- a/tests/prompts/test_correct_error_prompt.py
+++ b/tests/prompts/test_correct_error_prompt.py
@@ -2,8 +2,6 @@
 
 from datetime import date
 
-import pytest
-
 from pandasai.prompts.correct_error_prompt import CorrectErrorPrompt
 
 

--- a/tests/prompts/test_correct_multiples_prompt.py
+++ b/tests/prompts/test_correct_multiples_prompt.py
@@ -1,9 +1,6 @@
 """Unit tests for the correct multiples prompt class"""
 
-from datetime import date
-
 import pandas as pd
-import pytest
 
 from pandasai.prompts.correct_multiples_prompt import (
     CorrectMultipleDataframesErrorPrompt,

--- a/tests/prompts/test_generate_python_code_prompt.py
+++ b/tests/prompts/test_generate_python_code_prompt.py
@@ -2,8 +2,6 @@
 
 from datetime import date
 
-import pytest
-
 from pandasai.prompts.generate_python_code import GeneratePythonCodePrompt
 
 

--- a/tests/prompts/test_generate_response_prompt.py
+++ b/tests/prompts/test_generate_response_prompt.py
@@ -1,9 +1,5 @@
 """Unit tests for generate response prompt class"""
 
-from datetime import date
-
-import pytest
-
 from pandasai.prompts.generate_response import GenerateResponsePrompt
 
 

--- a/tests/prompts/test_multiple_dataframes_prompt.py
+++ b/tests/prompts/test_multiple_dataframes_prompt.py
@@ -3,7 +3,6 @@
 from datetime import date
 
 import pandas as pd
-import pytest
 
 from pandasai.prompts.multiple_dataframes import MultipleDataframesPrompt
 


### PR DESCRIPTION
- Refactor tests closer to the interface.
- Remove unused imports and other linting.
- Resolve type hint errors.
- Add test for reading cache from file.

Motivation: https://softwareengineering.stackexchange.com/questions/380287/why-is-unit-testing-private-methods-considered-as-bad-practice

- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).