### PR TITLE
feat: move chart dir output to log

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -472,7 +472,7 @@ class PandasAI:
 
         # Add save chart code
         if self._save_charts:
-            code = add_save_chart(code, self._prompt_id)
+            code = add_save_chart(code, self._prompt_id, not self._verbose)
 
         # Get the code to run removing unsafe imports and df overwrites
         code_to_run = self._clean_code(code)

--- a/pandasai/helpers/save_chart.py
+++ b/pandasai/helpers/save_chart.py
@@ -1,5 +1,6 @@
 """Helper functions to save charts to a file, if plt.show() is called."""
 import ast
+import logging
 import os
 from itertools import zip_longest
 from os.path import dirname
@@ -48,13 +49,15 @@ def compare_ast(
     return node1 == node2
 
 
-def add_save_chart(code: str, folder_name: str) -> str:
+def add_save_chart(code: str, folder_name: str, print_save_dir: bool = True) -> str:
     """
     Add line to code that save charts to a file, if plt.show() is called.
 
     Args:
         code (str): Code to add line to.
         folder_name (str): Name of folder to save charts to.
+        print_save_dir (bool): Print the save directory to the console.
+            Defaults to True.
 
     Returns:
         str: Code with line added.
@@ -94,7 +97,10 @@ def add_save_chart(code: str, folder_name: str) -> str:
             new_body.append(ast.parse(f"plt.savefig(r'{chart_save_path}')"))
         new_body.append(node)
 
-    new_body.append(ast.parse(f"print(r'Charts saved to: {chart_save_dir}')"))
+    chart_save_msg = f"Charts saving to: {chart_save_dir}"
+    if print_save_dir:
+        print(chart_save_msg)
+    logging.info(chart_save_msg)
 
     new_tree = ast.Module(body=new_body)
     return astor.to_source(new_tree).strip()

--- a/tests/helpers/test_save_chart.py
+++ b/tests/helpers/test_save_chart.py
@@ -34,12 +34,9 @@ plt.show()
             if compare_ast(node, show_node, ignore_args=True)
         ][0]
         expected_node = ast.parse("plt.savefig()").body[0]
-        assert len(tree.body) == line_count + 2
+        assert len(tree.body) == line_count + 1
         assert compare_ast(
             tree.body[show_call_pos - 1], expected_node, ignore_args=True
-        )
-        assert compare_ast(
-            tree.body[-1], ast.parse("print()").body[0], ignore_args=True
         )
 
     def test_save_multiple_charts(self):
@@ -62,7 +59,7 @@ plt.show()
         ]
         expected_node = ast.parse("plt.savefig()").body[0]
 
-        assert len(tree.body) == line_count + 3
+        assert len(tree.body) == line_count + 2
 
         # check first node is plt.savefig() and filename ends with a
         actual_node = tree.body[show_call_pos[0] - 1]


### PR DESCRIPTION
Return the chart save directory to the user using the logging framework instead of adding a print statement to the run code. When `verbose=False`, print directory to the console.

- [x] Closes #267 
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).