### PR TITLE
fix: remove non-optional dependencies from VERSIONS

### DIFF
--- a/pandasai/helpers/_optional.py
+++ b/pandasai/helpers/_optional.py
@@ -22,8 +22,6 @@ VERSIONS = {
     "seaborn": "0.12.2",
     "plotly": "5.14.1",
     "ggplot": "0.11.5",
-    "numpy": "1.21.2",
-    "matplotlib": "3.7.3",
     "scipy": "1.9.0",
 }
 


### PR DESCRIPTION
The package manager enforces the versions of non-optional dependencies.

- [x] closes #275
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
- [x] Plot charts integration test
