### PR TITLE
fix: type hinting error

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -235,7 +235,7 @@ class PandasAI:
 
     def run(
         self,
-        data_frame: pd.DataFrame,
+        data_frame: Union[pd.DataFrame, List[pd.DataFrame]],
         prompt: str,
         is_conversational_answer: bool = None,
         show_code: bool = False,
@@ -246,7 +246,7 @@ class PandasAI:
         Run the PandasAI to make Dataframes Conversational.
 
         Args:
-            data_frame (pd.Dataframe): A pandas Dataframe
+            data_frame (Union[pd.DataFrame, List[pd.DataFrame]]): A pandas Dataframe
             prompt (str): A prompt to query about the Dataframe
             is_conversational_answer (bool): Whether to return answer in conversational
             form. Default to False
@@ -373,7 +373,7 @@ class PandasAI:
 
     def __call__(
         self,
-        data_frame: pd.DataFrame,
+        data_frame: Union[pd.DataFrame, List[pd.DataFrame]],
         prompt: str,
         is_conversational_answer: bool = None,
         show_code: bool = False,


### PR DESCRIPTION
Fix type hint for `data_frame` parameter across methods of `PandasAI` class. According to [L275 of `__init__.py`](https://github.com/gventuri/pandas-ai/blob/main/pandasai/__init__.py#L275) the parameter can be a list of `DataFrame` objects.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
