### PR TITLE
chore(examples): add azure openai example

### DIFF
--- a/examples/from_dataframe_azure.py
+++ b/examples/from_dataframe_azure.py
@@ -1,0 +1,28 @@
+"""Example of using PandasAI with a Pandas DataFrame"""
+
+import pandas as pd
+from data.sample_dataframe import dataframe
+
+from pandasai import PandasAI
+from pandasai.llm.azure_openai import AzureOpenAI
+
+df = pd.DataFrame(dataframe)
+
+# export OPENAI_API_BASE=https://your-resource-name.openai.azure.com
+# export OPENAI_API_KEY=<your Azure OpenAI API key>
+
+# The name of your deployed model
+# This will correspond to the custom name you chose for your
+# deployment when you deployed a model.
+deployment_name = 'YOUR-MODEL-DEPLOYMENT-NAME'
+
+llm = AzureOpenAI(
+    deployment_name=deployment_name,
+    api_version="2023-05-15",
+    # is_chat_model=True, # Comment in if you deployed a chat model
+)
+
+pandas_ai = PandasAI(llm, verbose=True)
+response = pandas_ai(df, "Calculate the sum of the gdp of north american countries")
+print(response)
+# Output: 20901884461056

--- a/pandasai/llm/azure_openai.py
+++ b/pandasai/llm/azure_openai.py
@@ -34,13 +34,13 @@ class AzureOpenAI(BaseOpenAI):
     engine: str
 
     def __init__(
-        self,
-        api_token: Optional[str] = None,
-        api_base: Optional[str] = None,
-        api_version: Optional[str] = None,
-        deployment_name: str = None,
-        is_chat_model: Optional[bool] = False,
-        **kwargs,
+            self,
+            api_token: Optional[str] = None,
+            api_base: Optional[str] = None,
+            api_version: Optional[str] = None,
+            deployment_name: str = None,
+            is_chat_model: Optional[bool] = False,
+            **kwargs,
     ):
         """
         __init__ method of AzureOpenAI Class
@@ -58,14 +58,24 @@ class AzureOpenAI(BaseOpenAI):
             **kwargs: Inference Parameters
         """
 
-        self.api_token = api_token or os.getenv("AZURE_OPENAI_KEY") or None
-        self.api_base = api_base or os.getenv("AZURE_OPENAI_ENDPOINT") or None
-        self.api_version = api_version or "2023-05-15"
+        self.api_token = api_token or os.getenv("OPENAI_API_KEY") or None
+        self.api_base = api_base or os.getenv("OPENAI_API_BASE") or None
+        self.api_version = api_version or os.getenv("OPENAI_API_VERSION")
         if self.api_token is None:
-            raise APIKeyNotFoundError("Azure OpenAI key is required")
+            raise APIKeyNotFoundError(
+                "Azure OpenAI key is required. Please add an environment variable "
+                "`OPENAI_API_KEY` or pass `api_token` as a named parameter"
+            )
         if self.api_base is None:
-            raise APIKeyNotFoundError("Azure OpenAI base endpoint is required")
-
+            raise APIKeyNotFoundError(
+                "Azure OpenAI base is required. Please add an environment variable "
+                "`OPENAI_API_BASE` or pass `api_base` as a named parameter"
+            )
+        if self.api_version is None:
+            raise APIKeyNotFoundError(
+                "Azure OpenAI version is required. Please add an environment variable "
+                "`OPENAI_API_VERSION` or pass `api_version` as a named parameter"
+            )
         openai.api_key = self.api_token
         openai.api_base = self.api_base
         openai.api_version = self.api_version

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -17,20 +17,27 @@ class TestAzureOpenAILLM:
         with pytest.raises(APIKeyNotFoundError):
             AzureOpenAI(api_token="test")
 
-    def test_type_without_deployment(self):
-        with pytest.raises(UnsupportedOpenAIModelError):
+    def test_type_without_api_version(self):
+        with pytest.raises(APIKeyNotFoundError):
             AzureOpenAI(api_token="test", api_base="test")
 
-    def test_type_with_token(self, mocker):
-        assert (
-                AzureOpenAI(api_token="test", api_base="test", deployment_name="test").type
-                == "azure-openai"
-        )
+    def test_type_without_deployment(self):
+        with pytest.raises(UnsupportedOpenAIModelError):
+            AzureOpenAI(api_token="test", api_base="test", api_version="test")
 
-    def test_params_setting(self, mocker):
+    def test_type_with_token(self):
+        assert AzureOpenAI(
+            api_token="test",
+            api_base="test",
+            api_version="test",
+            deployment_name="test"
+        ).type == "azure-openai"
+
+    def test_params_setting(self):
         llm = AzureOpenAI(
             api_token="test",
             api_base="test",
+            api_version="test",
             deployment_name="Deployed-GPT-3",
             is_chat_model=True,
             temperature=0.5,
@@ -55,7 +62,12 @@ class TestAzureOpenAILLM:
         expected_text = "This is the generated text."
         openai_mock.return_value = {"choices": [{"text": expected_text}]}
 
-        openai = AzureOpenAI(api_token="test", api_base="test", deployment_name="test")
+        openai = AzureOpenAI(
+            api_token="test",
+            api_base="test",
+            api_version="test",
+            deployment_name="test"
+        )
         result = openai.completion("Some prompt.")
 
         openai_mock.assert_called_once_with(
@@ -74,6 +86,7 @@ class TestAzureOpenAILLM:
         openai = AzureOpenAI(
             api_token="test",
             api_base="test",
+            api_version="test",
             deployment_name="test",
             is_chat_model=True
         )


### PR DESCRIPTION
Hi @gventuri, this PR adds an example showcasing how to use `AzureOpenAI` and refactors a bit the content of the Azure backend (mainly forcing the user to specify an `api_version` for proper usage)

- [X] closes #293 
- [X] add additional tests
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
