### PR TITLE
tests: fix signature of a method in a fixture

### DIFF
--- a/tests/llms/test_langchain_llm.py
+++ b/tests/llms/test_langchain_llm.py
@@ -16,7 +16,7 @@ class TestLangchainLLM:
         class FakeOpenAI(OpenAI):
             openai_api_key = "fake_key"
 
-            def __call__(self, _prompt):
+            def __call__(self, _prompt, stop=None, callbacks=None, **kwargs):
                 return Mock(return_value="Custom response")()
 
         langchain_llm = FakeOpenAI()


### PR DESCRIPTION
Minor fix:
Update signature for `__call__()` method of `FakeOpenAI` mock according to it's base class.
Although it seems like it has no effect for now, because [the only place i found of usage](https://github.com/gventuri/pandas-ai/blob/main/pandasai/llm/langchain.py#L18) for that is just passing only `prompt` parameter. But i think it'd be better to keep method's original signature anyway, this basically seems to remove violation of Liskov Abstraction principle.

- [x] closes #xxxx (Replace xxxx with the GitHub issue number) _(No issue was created, minor fix)_
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
