### PR TITLE
tests: fix failing tests for win platform (#347)

### DIFF
--- a/tests/test_pandasai.py
+++ b/tests/test_pandasai.py
@@ -1,5 +1,6 @@
 """Unit tests for the PandasAI class"""
 
+import sys
 from datetime import date
 from typing import Optional
 from unittest.mock import Mock, patch
@@ -194,7 +195,10 @@ How many countries are in the dataframe?
 Code:
 """  # noqa: E501
         pandasai.run(df, "How many countries are in the dataframe?")
-        assert pandasai._llm.last_prompt == expected_prompt
+        last_prompt = pandasai._llm.last_prompt
+        if sys.platform.startswith('win'):
+            last_prompt = last_prompt.replace('\r\n', '\n')
+        assert last_prompt == expected_prompt
 
     def test_run_with_anonymized_df(self, pandasai):
         df = pd.DataFrame(
@@ -258,7 +262,10 @@ How many countries are in the dataframe?
 Code:
 """  # noqa: E501
         pandasai.run(df, "How many countries are in the dataframe?", anonymize_df=False)
-        assert pandasai._llm.last_prompt == expected_prompt
+        last_prompt = pandasai._llm.last_prompt
+        if sys.platform.startswith('win'):
+            last_prompt = last_prompt.replace('\r\n', '\n')
+        assert last_prompt == expected_prompt
 
     def test_run_with_print_at_the_end(self, pandasai, llm):
         code = """


### PR DESCRIPTION
This patch is for contributors who are developing on Windows platform. Some tests were failing because of [`\r\n` instead of `\n`](https://www.cs.toronto.edu/~krueger/csc209h/tut/line-endings.html#:~:text=Text%20files%20created%20on%20DOS,(%22%5Cn%22).), the problem described in issue https://github.com/gventuri/pandas-ai/issues/347

___

Add [checking for platform](https://docs.python.org/3/library/sys.html#sys.platform) in some test cases and replacing `\r\n` with `\n` if the platform's name starts with `"win"`.

* add compatibility for win platforms in [`test_run_with_privacy_enforcement()`](https://github.com/gventuri/pandas-ai/blob/main/tests/test_pandasai.py#L197)

* add compatibility for win platforms in [`test_run_without_privacy_enforcement()`](https://github.com/gventuri/pandas-ai/blob/main/tests/test_pandasai.py#L261)

- [x] closes #347
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).

___

p. s. i guess it would be great to move some fixtures in files (too much hardcoded multiline texts in tests modules) or generating them via [Faker](https://pypi.org/project/Faker/). I'd be glad to hear an outside perspective about that.
