### PR TITLE
ci: run on windows and macos latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:


### PR DESCRIPTION
Given the experience coming from this [issue](https://github.com/gventuri/pandas-ai/issues/347), this PR aims at making the CI pipeline run on windows and macOS as well.