### PR TITLE
feat: passing log level in `log()` method (#368)

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -155,7 +155,7 @@ class PandasAI(Shortcuts):
     _start_time: float = 0
     _enable_logging: bool = True
     _logger: logging.Logger = None
-    _logs: List[str] = []
+    _logs: List[dict[str, str]] = []
     last_code_generated: Optional[str] = None
     last_code_executed: Optional[str] = None
     code_output: Optional[str] = None
@@ -708,13 +708,20 @@ Code running:
         except Exception:
             return captured_output
 
-    def log(self, message: str):
-        """Log a message"""
-        self._logger.info(message)
-        self._logs.append(message)
+    def log(self, message: str, level: Optional[int] = logging.INFO):
+        """
+        Log the passed message with according log level.
+
+        Args:
+            message (str): a message string to be logged
+            level (Optional[int]): an integer, representing log level;
+                                   default to 20 (INFO)
+        """
+        self._logger.log(level=level, msg=message)
+        self._logs.append({"msg": message, "level": level})
 
     @property
-    def logs(self) -> List[str]:
+    def logs(self) -> List[dict[str, str]]:
         """Return the logs"""
         return self._logs
 

--- a/tests/test_pandasai.py
+++ b/tests/test_pandasai.py
@@ -1,5 +1,5 @@
 """Unit tests for the PandasAI class"""
-
+import logging
 import sys
 from datetime import date
 from typing import Optional
@@ -791,9 +791,23 @@ print('Hello', name)"""
     def test_saves_logs(self, llm):
         pandas_ai = PandasAI(llm)
         assert pandas_ai.logs == []
-        pandas_ai.log("a")
-        pandas_ai.log("b")
-        assert pandas_ai.logs == [
-            "a",
-            "b",
-        ]
+
+        debug_msg = "Some debug log"
+        info_msg = "Some info log"
+        warning_msg = "Some warning log"
+        error_msg = "Some error log"
+        critical_msg = "Some critical log"
+
+        pandas_ai.log(debug_msg, level=logging.DEBUG)
+        pandas_ai.log(info_msg)  # INFO should be default
+        pandas_ai.log(warning_msg, level=logging.WARNING)
+        pandas_ai.log(error_msg, level=logging.ERROR)
+        pandas_ai.log(critical_msg, level=logging.CRITICAL)
+        logs = pandas_ai.logs
+
+        assert all("msg" in log and "level" in log for log in logs)
+        assert {"msg": debug_msg, "level": logging.DEBUG} in logs
+        assert {"msg": info_msg, "level": logging.INFO} in logs
+        assert {"msg": warning_msg, "level": logging.WARNING} in logs
+        assert {"msg": error_msg, "level": logging.ERROR} in logs
+        assert {"msg": critical_msg, "level": logging.CRITICAL} in logs


### PR DESCRIPTION
This commit adds possibility to specify log level when calling `.log()` method from `PandasAI` class.

The `INFO` level remains to be default value, so it won't affect any part of existing code.
___

* feat: update `log()` method of `PandasAI`, add passing log level as a parameter
* feat: add saving log level in logs container
* feat: update typing accordingly
* tests: update test for saving logs, add checking of logging for different levels

- [x] closes #368 
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
