### PR TITLE
docs: fix api_key param

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -12,7 +12,7 @@ Once you have an API key, you can use it to instantiate an OpenAI object:
 from pandasai import PandasAI
 from pandasai.llm.openai import OpenAI
 
-llm = OpenAI(openai_api_key="my-openai-api-key")
+llm = OpenAI(api_key="my-openai-api-key")
 pandas_ai = PandasAI(llm=llm)
 ```
 
@@ -77,9 +77,9 @@ from pandasai import PandasAI
 from pandasai.llm.starcoder import Starcoder
 from pandasai.llm.falcon import Falcon
 
-llm = Starcoder(huggingface_api_key="my-huggingface-api-key")
+llm = Starcoder(api_key="my-huggingface-api-key")
 # or
-llm = Falcon(huggingface_api_key="my-huggingface-api-key")
+llm = Falcon(api_key="my-huggingface-api-key")
 
 pandas_ai = PandasAI(llm=llm)
 ```
@@ -108,7 +108,7 @@ Once you have an API key, you can use it to instantiate a Google PaLM object:
 from pandasai import PandasAI
 from pandasai.llm.google_palm import GooglePalm
 
-llm = GooglePalm(google_cloud_api_key="my-google-cloud-api-key")
+llm = GooglePalm(api_key="my-google-cloud-api-key")
 pandas_ai = PandasAI(llm=llm)
 ```
 


### PR DESCRIPTION
Hi @gventuri, 
this PR fixes the llms documentation and specifically the naming of the api key parameter, which is called `api_key` for all of them.

- [X] closes #387 
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).

I make the most of this PR to ask if you prefer to have "langchain-like" naming instead, i.e. `<provider>_api_<type>` (`huggingface_api_token`, `openai_api_type` etc.). If it is the case, we gotta change the parameters naming in the classes API. I can do that appending a commit to this PR. 
Otherwise, this is ready for review :)