### PR TITLE
feat: support for gpt4all and models supported by gpt4all

### DIFF
--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -8,6 +8,7 @@ Example:
 
     >>> from pandasai.llm.gpt4all import GPT4AllLLM
 """
+import logging
 import os
 import requests
 from typing import Optional

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -222,10 +222,16 @@ class GPT4AllLLM(LLM):
                 print(f"=> Model: {self.model_name} downloaded successfully 🥳")
 
             else:
-                print(
-                    f"{self.model_name} does not exists in {self.model_folder_path}",
-                    "Please either download the model by allow_download = True",
+                logger.error(
+                    f"'{self.model_name}' does not exists in "
+                    f"'{self.model_folder_path}'. Please either let the model "
+                    f"to be downloaded automatically (by passing "
+                    f"`allow_download=True`) or download the model manually.",
                 )
+                raise LLMNotFoundError(
+                    f"Unable to find the model {self.model_name} in"
+                    f" {self.model_folder_path}"
+
 
     @property
     def type(self) -> str:

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -154,19 +154,11 @@ class GPT4AllLLM(LLM):
             logger.info(f"Model {model_name} saved as: {self.model_folder_path}")
 
         n_threads = self.n_threads if n_threads is None else n_threads
-        try:
-            from gpt4all import GPT4All
-
-            self.gpt4all_model = GPT4All(
-                model_name=self.model_name,
-                model_path=self.model_folder_path,
-                n_threads=n_threads,
-            )
-        except ImportError:
-            raise ImportError(
-                "Unable to import gpt4all python package "
-                "Please install it with `pip install -U gpt4all`"
-            )
+        self.gpt4all_model = GPT4All(
+            model_name=self.model_name,
+            model_path=self.model_folder_path,
+            n_threads=n_threads,
+        )
 
         self.default_parameters = {
             "max_tokens": self.max_tokens,

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -61,7 +61,7 @@ class UnableToDownloadGPT4AllBin(Exception):
 
 class GPT4AllLLM(LLM):
     """GPT4All LLMs API
-    Base LLM class is extended to support GPT4AllLLM. When this class will be
+    Base LLM class is extended to support GPT4All LLM. When this class will be
     initialized all the additional parameters like temp, top_p, top_k etc should
     be inside **kwargs while instantiating the class. That is to be done only if
     the user wants to override the existing configurations. Below example shows how

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -27,6 +27,37 @@ except ImportError:
 from pandasai.prompts.base import Prompt
 from .base import LLM
 
+logger = logging.getLogger(__name__)
+
+
+class UnableToDownloadGPT4AllBin(Exception):
+    """
+    Raised when unable to automatically download the GPT4All LLM.
+
+    Args:
+        Exception (Exception): UnableToDownloadGPT4AllBin
+    """
+
+    def __init__(self, gpt4all_bin_filename=None, time_spent=None):
+        """
+        Initialize `UnableToDownloadGPT4AllBin` instance.
+
+        Args:
+            gpt4all_bin_filename (Optional[str]): Name of the binary file of
+                the GPT4All model.
+            time_spent (Optional[int]): Time in seconds spent for
+                downloading process.
+        """
+
+        self.gpt4all_bin_filename = gpt4all_bin_filename
+        self.time_s_spent = time_spent
+
+        super().__init__(
+            f"Unable to download the model. "
+            f"Model filename: {gpt4all_bin_filename or 'Unknown'}; "
+            f"Time spent: {time_spent or 'Unknown'}"
+        )
+
 
 class GPT4AllLLM(LLM):
     """GPT4All LLMs API

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -151,7 +151,7 @@ class GPT4AllLLM(LLM):
         self.allow_download = allow_download
         if allow_download:
             self._auto_download()
-            print(f"Model {model_name} saved as: {self.model_folder_path}")
+            logger.info(f"Model {model_name} saved as: {self.model_folder_path}")
 
         n_threads = self.n_threads if n_threads is None else n_threads
         try:

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -207,9 +207,12 @@ class GPT4AllLLM(LLM):
                             if chunk:
                                 f.write(chunk)
 
-                except Exception as e:
-                    print(f"=> Download Failed. Error: {e}")
-                    return
+                except Exception as exc:
+                    logger.error("=> Download Failed.", exc_info=True)
+                    raise UnableToDownloadGPT4AllBin(
+                        gpt4all_bin_filename=self.model_name,
+                        time_spent=(int(time.time()) - start_downloading_ts),
+                    ) from exc
 
                 print(f"=> Model: {self.model_name} downloaded sucessfully 🥳")
 

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -175,10 +175,19 @@ class GPT4AllLLM(LLM):
         self.params = {**self.default_parameters, **kwargs}
 
     def _auto_download(self) -> None:
-        # import all the required dependencies
-        import requests
-        from tqdm import tqdm
+        """
+        Automatically download GPT4All binary file.
 
+        Download from gpt4all.io using the following URL:
+        `https://gpt4all.io/models/<self.model_name>`
+        where `model_name` is the name of binary file of the model.
+
+        The downloading starts if `self.allow_download` is `True` and
+        a binary file (supposed to contain content of the model)
+        was not found in `download_path`.
+
+        Raises:
+        """
         download_path = os.path.join(self.model_folder_path, self.model_name)
 
         if not os.path.exists(download_path):

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -194,10 +194,10 @@ class GPT4AllLLM(LLM):
             if self.allow_download:
                 # send a GET request to the URL to download the file.
                 # Stream it while downloading, since the file is large
+                url = f"https://gpt4all.io/models/{self.model_name}"
 
+                start_downloading_ts = time.time()
                 try:
-                    url = f"https://gpt4all.io/models/{self.model_name}"
-
                     response = requests.get(url, stream=True)
 
                     with open(download_path, "wb") as f:

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -1,0 +1,181 @@
+"""GPT4All LLMs
+This module provides a family of commercially / non-commercially available 
+LLMs maintained by Nomic AI. With GPT4All we can easily download models like 
+Falcon, Llama etc and run them seamlessly using CPU with lower RAMs. 
+
+Example:
+    Use below example to call GPT4All supporrted models
+
+    >>> from pandasai.llm.gpt4all import GPT4AllLLM
+"""
+import os
+import requests
+from typing import Optional
+
+from pandasai.prompts.base import Prompt
+from .base import LLM
+
+
+class GPT4AllLLM(LLM):
+    """GPT4All LLMs API
+    Base LLM class is extended to support GPT4AllLLM. When this class will be
+    initialized all the additional parameters like temp, top_p, top_k etc should
+    be inside **kwargs while instantiating the class. That is to be done only if
+    the user wants to override the existing configurations. Below example shows how
+    we can use override certain configurations to change model's behaviour.
+
+    Example:
+        >>> import pandas as pd
+        >>> from pandasai import PandasAI
+        >>> from pandasai.llm.gpt4all import GPT4AllLLM
+
+        >>> model_name = 'ggml-replit-code-v1-3b.bin'
+        >>> additional_params = {'temp': 0, 'max_tokens': 50}
+        >>> model = GPT4AllLLM(model_name, allow_download=True, **additional_params)
+
+        >>> df_ai = PandasAI(model)
+        >>> response = df_ai(df, prompt='What is the sum of the GDP in this table?')
+
+    There is an optional parameter called model_path which sets where to
+    download the model and if it is not set then it will download the model
+    inside the folder: home/<user-name>/.local/share/nomic.ai/GPT4All/
+    Note: Please note that right now Pandas AI only supports models for gpt4all. However
+    it might not work as chatGPT when it comes to performance, hence for now users using
+    this module have to tune the existing prompts to get better results.
+    """
+
+    temp: Optional[float] = 0
+    top_p: Optional[float] = 0.1
+    top_k: Optional[int] = 40
+    n_batch: Optional[int] = 8
+    n_threads: Optional[int] = 4
+    n_predict: Optional[int] = 256
+    max_tokens: Optional[int] = 200
+    repeat_last_n: Optional[int] = 64
+    repeat_penalty: Optional[float] = 1.18
+
+    _model_repo_url = "https://gpt4all.io/models/models.json"
+    _supported_models = [
+        metadata["filename"] for metadata in requests.get(_model_repo_url).json()
+    ]
+
+    def __init__(
+        self,
+        model_name: str,
+        model_folder_path: Optional[str] = None,
+        allow_download: Optional[bool] = False,
+        n_threads: Optional[int] = 4,
+        download_chunk_size: Optional[int] = 8912,
+        **kwargs,
+    ) -> None:
+        """
+        GPT4All client for using Pandas AI
+        Args:
+            model_name: The name of the model.
+            model_folder_path: The folder inside the model weights are present
+            allow_download: If True will trigger download the specified model
+            n_threads: Number of CPU threads to be used while running the model
+            download_chunk_size: The chunk size set for downloading the model
+        """
+        self.model_name = (
+            f"{model_name}.bin" if not model_name.endswith(".bin") else model_name
+        )
+        self.chunk_size = download_chunk_size
+
+        _assert_msg = (
+            "Model not Found. Please check the list of supported models:",
+            self._supported_models,
+        )
+        assert self.model_name in self._supported_models, _assert_msg
+
+        # automatically download inside that folder
+        _default_download_path = os.path.join(
+            os.path.expanduser("~"), ".local/share/nomic.ai/GPT4All/"
+        )
+
+        self.model_folder_path = (
+            _default_download_path if model_folder_path is None else model_folder_path
+        )
+
+        # automatically create the default folder and download the model
+
+        if not os.path.exists(self.model_folder_path) and allow_download:
+            os.mkdir(self.model_folder_path)
+
+        if allow_download:
+            self._auto_download()
+            print(f"Model {model_name} saved as: {self.model_folder_path}")
+
+        n_threads = self.n_threads if n_threads is None else n_threads
+        try:
+            from gpt4all import GPT4All
+
+            self.gpt4all_model = GPT4All(
+                model_name=self.model_name,
+                model_path=self.model_folder_path,
+                n_threads=n_threads,
+            )
+        except ImportError:
+            raise ImportError(
+                "Unable to import gpt4all python package "
+                "Please install it with `pip install -U gpt4all`"
+            )
+
+        self.default_parameters = {
+            "max_tokens": self.max_tokens,
+            "n_predict": self.n_predict,
+            "top_k": self.top_k,
+            "top_p": self.top_p,
+            "temp": self.temp,
+            "n_batch": self.n_batch,
+            "repeat_penalty": self.repeat_penalty,
+            "repeat_last_n": self.repeat_last_n,
+        }
+
+        # this will override all the parameters with all the pre-existing ones
+        self.params = {**self.default_parameters, **kwargs}
+
+    def _auto_download(self) -> None:
+        # import all the required dependencies
+        import requests
+        from tqdm import tqdm
+
+        download_path = os.path.join(self.model_folder_path, self.model_name)
+
+        if not os.path.exists(download_path):
+            if self.allow_download:
+                # send a GET request to the URL to download the file.
+                # Stream it while downloading, since the file is large
+
+                try:
+                    url = f"https://gpt4all.io/models/{self.model_name}"
+
+                    response = requests.get(url, stream=True)
+
+                    with open(download_path, "wb") as f:
+                        for chunk in tqdm(
+                            response.iter_content(chunk_size=self.chunk_size)
+                        ):
+                            if chunk:
+                                f.write(chunk)
+
+                except Exception as e:
+                    print(f"=> Download Failed. Error: {e}")
+                    return
+
+                print(f"=> Model: {self.model_name} downloaded sucessfully 🥳")
+
+            else:
+                print(
+                    f"{self.model_name} does not exists in {self.model_folder_path}",
+                    "Please either download the model by allow_download = True",
+                )
+
+    @property
+    def type(self) -> str:
+        return "gpt4all"
+
+    def call(self, instruction: Prompt, value: str, suffix: str = "") -> str:
+        prompt = str(instruction)
+        prompt = prompt + value + suffix
+        return self.gpt4all_model.generate(prompt, **self.params)

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -14,6 +14,16 @@ import sys
 import time
 from typing import Optional
 
+import requests
+from tqdm import tqdm
+try:
+    from gpt4all import GPT4All
+except ImportError:
+    raise ImportError(
+        "Unable to import gpt4all python package "
+        "Please install it with `pip install -U gpt4all`"
+    )
+
 from pandasai.prompts.base import Prompt
 from .base import LLM
 

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -214,7 +214,12 @@ class GPT4AllLLM(LLM):
                         time_spent=(int(time.time()) - start_downloading_ts),
                     ) from exc
 
-                print(f"=> Model: {self.model_name} downloaded sucessfully 🥳")
+                logger.info(
+                    f"The model was successfully downloaded in "
+                    f"{(int(time.time()) - start_downloading_ts)} seconds."
+                )
+
+                print(f"=> Model: {self.model_name} downloaded successfully 🥳")
 
             else:
                 print(

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -98,6 +98,10 @@ class GPT4AllLLM(LLM):
     repeat_penalty: Optional[float] = 1.18
 
     _model_repo_url = "https://gpt4all.io/models/models.json"
+    _default_download_path_unix = os.path.join(
+        os.path.expanduser("~"), ".local/share/nomic.ai/GPT4All/"
+    )
+    _default_download_path_win = os.path.join(os.path.expanduser("~"), ".gpt4all\\")
     _supported_models = [
         metadata["filename"] for metadata in requests.get(_model_repo_url).json()
     ]

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -140,7 +140,7 @@ class GPT4AllLLM(LLM):
             default_download_path = self._default_download_path_win
 
         self.model_folder_path = (
-            _default_download_path if model_folder_path is None else model_folder_path
+            default_download_path if model_folder_path is None else model_folder_path
         )
 
         # automatically create the default folder and download the model

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 import requests
 from tqdm import tqdm
+
 try:
     from gpt4all import GPT4All
 except ImportError:
@@ -26,6 +27,7 @@ except ImportError:
 
 from pandasai.prompts.base import Prompt
 from .base import LLM
+from pandasai.exceptions import LLMNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +148,7 @@ class GPT4AllLLM(LLM):
         # automatically create the default folder and download the model
 
         if not os.path.exists(self.model_folder_path) and allow_download:
-            os.mkdir(self.model_folder_path)
+            os.makedirs(self.model_folder_path)
 
         self.allow_download = allow_download
         if allow_download:
@@ -231,7 +233,7 @@ class GPT4AllLLM(LLM):
                 raise LLMNotFoundError(
                     f"Unable to find the model {self.model_name} in"
                     f" {self.model_folder_path}"
-
+                )
 
     @property
     def type(self) -> str:

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -135,10 +135,9 @@ class GPT4AllLLM(LLM):
         )
         assert self.model_name in self._supported_models, _assert_msg
 
-        # automatically download inside that folder
-        _default_download_path = os.path.join(
-            os.path.expanduser("~"), ".local/share/nomic.ai/GPT4All/"
-        )
+        default_download_path = self._default_download_path_unix
+        if sys.platform.startswith("win"):
+            default_download_path = self._default_download_path_win
 
         self.model_folder_path = (
             _default_download_path if model_folder_path is None else model_folder_path

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -10,7 +10,8 @@ Example:
 """
 import logging
 import os
-import requests
+import sys
+import time
 from typing import Optional
 
 from pandasai.prompts.base import Prompt

--- a/pandasai/llm/gpt4all.py
+++ b/pandasai/llm/gpt4all.py
@@ -148,6 +148,7 @@ class GPT4AllLLM(LLM):
         if not os.path.exists(self.model_folder_path) and allow_download:
             os.mkdir(self.model_folder_path)
 
+        self.allow_download = allow_download
         if allow_download:
             self._auto_download()
             print(f"Model {model_name} saved as: {self.model_folder_path}")

--- a/tests/llms/test_gpt4all.py
+++ b/tests/llms/test_gpt4all.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import patch
+from pandasai.llm.gpt4all import GPT4AllLLM
+
+
+class TestGPT4AllLLM(unittest.TestCase):
+    """Unit tests for the base GPT4All LLM class"""
+
+    def setUp(self):
+        self.model_name = "ggml-all-MiniLM-L6-v2-f16.bin"
+        self.model_folder_path = None
+        self.n_threads = 4
+        self.gpt4all_model = GPT4AllLLM(
+            model_name=self.model_name,
+        )
+
+    @patch("pandasai.llm.gpt4all.GPT4AllLLM._auto_download")
+    def test_type(self, mock_download_model):
+        mock_download_model.return_value = "/path/to/dummy/model.bin"
+        mock_download_model.assert_not_called()
+        assert self.gpt4all_model.type == "gpt4all"


### PR DESCRIPTION
This commit supports gpt4all models by nomic ai for supporting pandaAI on device without any kind of GPU capabilities. Here are the key features of the prompts

1) automatic download of the models when mentioned the model path and name 
2) Users can integrate this with PandasAI class as it supports that now 
3) User can download wide range of models like llama, falcon, replit-3b etc.

- [X] closes #396 
- [X] Tests added and passed if fixing a bug or adding a new feature.

Tests are not currently supported for gpt4all models. It will be very soon. More explained below the discussion section. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Introduced a new module `GPT4AllLLM` that extends the `LLM` class.
- Added support for GPT4All language models in Pandas AI.
- Implemented automatic model downloading and initialization.
- Provided options to override default configurations.
- Included error handling for model download failures.

> 🎉🐇
> 
> Hopping through the code, what do we see?
> A shiny new feature, as bright as can be!
> GPT4All now in our grasp,
> Making AI tasks an easy clasp.
> Download, initialize, and run with glee,
> Oh, how happy this rabbit will be! 🥳🎉
<!-- end of auto-generated comment: release notes by coderabbit.ai -->