### PR TITLE
refactor: update `_get_prompt()` in `PandasAI`

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -308,6 +308,12 @@ class PandasAI(Shortcuts):
         if default_values is None:
             default_values = {}
 
+        # prompt builtins are available to all prompts preceded by $
+        # e.g. $df.head(), $df.shape, $df.columns, etc.
+        prompt_builtins = {
+            "df": df,
+        }
+
         prompt = self._non_default_prompts.get(key)
 
         if prompt and isinstance(prompt, type):
@@ -325,7 +331,7 @@ class PandasAI(Shortcuts):
                 word = prompt_text[i]
 
                 if word.startswith("$"):
-                    prompt_text[i] = str(eval(word[1:]))
+                    prompt_text[i] = str(eval(word[1:], prompt_builtins))
             prompt.text = " ".join(prompt_text)
 
             return prompt, prompt._args
@@ -392,7 +398,7 @@ class PandasAI(Shortcuts):
                         "multiple_dataframes",
                         default_prompt=MultipleDataframesPrompt,
                         default_values=multiple_dataframes_default_values,
-                        df=heads,
+                        df=data_frame,
                     )
 
                     code = self._llm.generate_code(

--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -299,8 +299,14 @@ class PandasAI(Shortcuts):
         return self._llm.call(generate_response_instruction, "")
 
     def _get_prompt(
-        self, key: str, default_prompt: Prompt, default_values: Dict = {}, df=None
-    ):
+        self,
+        key: str,
+        default_prompt: Type[Prompt],
+        default_values: Optional[dict] = None,
+    ) -> tuple[Prompt, dict]:
+        if default_values is None:
+            default_values = {}
+
         prompt = self._non_default_prompts.get(key)
 
         if prompt and isinstance(prompt, type):

--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -303,6 +303,7 @@ class PandasAI(Shortcuts):
         key: str,
         default_prompt: Type[Prompt],
         default_values: Optional[dict] = None,
+        df=None,
     ) -> tuple[Prompt, dict]:
         if default_values is None:
             default_values = {}


### PR DESCRIPTION
There are some cosmetic things merged in https://github.com/gventuri/pandas-ai/pull/392 that i guess would rather be refactored.

___

Mutual default parameter in the method's signature. Mutual default arguments (like `values: Dict = {}`) can cause unpredictable behavior.
```
>>> def foobar(bar=[]):
...     bar.append('test')
...     print(f'List {bar} with ID {id(bar)}')
>>>
>>>
>>> foobar()
List ['test'] with ID 140147921265664
>>> foobar()
List ['test', 'test'] with ID 140147921265664  # as you see function hasn't create an empty list during second call, instead picked already existed
```
I've shown example with a list, but it's works same for dict, etc. (basically any mutual object).

See:
https://stackoverflow.com/questions/1132941/least-astonishment-and-the-mutable-default-argument
https://web.archive.org/web/20200221224620id_/http://effbot.org/zone/default-values.htm

___

Type annotation. For the parameter `default_prompt` it was specified just `Prompt` when it should be rather `Type[Prompt]` (cause it's supposed to accept type-object, not the instance itself)

See:
https://docs.python.org/3/library/typing.html#the-type-of-class-objects

___

Type annotation. Add annotations for return values.

___

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
