### PR TITLE
fix: environment for executing code

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -781,6 +781,11 @@ class PandasAI(Shortcuts):
                 )
             except Exception as new_exc:
                 exc = new_exc
+                self.log(
+                    f"Unable to fix `NameError`: an exception was raised: "
+                    f"{traceback.format_exc()}",
+                    level=logging.DEBUG,
+                )
 
         if not use_error_correction_framework:
             raise exc

--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -48,7 +48,6 @@ import importlib.metadata
 
 __version__ = importlib.metadata.version(__package__ or __name__)
 import astor
-import matplotlib
 import pandas as pd
 from .constants import (
     WHITELISTED_BUILTINS,
@@ -643,7 +642,6 @@ class PandasAI(Shortcuts):
 
         return {
             "pd": pd,
-            "plt": matplotlib.pyplot,
             **{
                 lib["alias"]: getattr(import_dependency(lib["module"]), lib["name"])
                 if hasattr(import_dependency(lib["module"]), lib["name"])
@@ -773,7 +771,7 @@ class PandasAI(Shortcuts):
                 if search_name_res := re.search(name_ptrn, exc.args[0]):
                     name_to_be_imported = search_name_res.group(1)
 
-            if name_to_be_imported:
+            if name_to_be_imported and name_to_be_imported in WHITELISTED_LIBRARIES:
                 try:
                     package = __import__(name_to_be_imported)
                     environment[name_to_be_imported] = package
@@ -811,6 +809,13 @@ class PandasAI(Shortcuts):
                 f"[retry number: {retry_num + 1}]",
                 level=logging.WARNING,
             )
+        else:
+            self.log(
+                f"Unable to fix {exc.__class__.__name__} with error "
+                f"correction framework",
+                level=logging.ERROR,
+            )
+            raise exc
 
         return code
 

--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -48,6 +48,7 @@ import importlib.metadata
 
 __version__ = importlib.metadata.version(__package__ or __name__)
 import astor
+import matplotlib
 import pandas as pd
 from .constants import (
     WHITELISTED_BUILTINS,
@@ -642,6 +643,7 @@ class PandasAI(Shortcuts):
 
         return {
             "pd": pd,
+            "plt": matplotlib.pyplot,
             **{
                 lib["alias"]: getattr(import_dependency(lib["module"]), lib["name"])
                 if hasattr(import_dependency(lib["module"]), lib["name"])

--- a/tests/test_pandasai.py
+++ b/tests/test_pandasai.py
@@ -146,6 +146,43 @@ class TestPandasAI:
             pandasai.run(df, "What number comes before 2?")
             mock_print.assert_not_called()
 
+    def test_execute_catching_errors_correct(self, pandasai):
+        code = "print(1 + 1)"
+        environment = {}
+
+        with patch("builtins.exec") as mock_exec:
+            assert pandasai._execute_catching_errors(code, environment) is None
+            mock_exec.assert_called_once_with(code, environment)
+
+    def test_execute_catching_errors_raise_exc(self, pandasai):
+        code = "raise RuntimeError()"
+        environment = {}
+
+        with patch("builtins.exec") as mock_exec:
+            mock_exec.side_effect = RuntimeError("foobar")
+            exc = pandasai._execute_catching_errors(code, environment)
+            mock_exec.assert_called_once_with(code, environment)
+            assert isinstance(exc, RuntimeError)
+
+    def test_handle_error_retry_with_correction_framework(self, pandasai):
+        code = "raise RuntimeError()"
+        environment = {}
+
+        exc = pandasai._execute_catching_errors(code, environment)
+        assert FakeLLM._output == pandasai.handle_error(
+            exc, code, environment, use_error_correction_framework=True, multiple=False
+        )
+
+    def test_handle_error_name_error(self, pandasai):
+        code = "print(os)"
+        environment = {}
+
+        exc = pandasai._execute_catching_errors(code, environment)
+        assert code == pandasai.handle_error(
+            exc, code, environment, use_error_correction_framework=False, multiple=False
+        )
+        assert getattr(environment.get("os"), "__name__", None) == "os"
+
     def test_run_code(self, pandasai):
         df = pd.DataFrame({"a": [1, 2, 3]})
         code = """


### PR DESCRIPTION
This PR should resolve the problem with environment described in issue #400.

For now i've just added `matplotlib.pyplot` as "plt" in `_get_environment()` method. The package is present in dependency list, code from the issue runs without failures, it must works OK.

However it's still unclear for me, should we add the rest of popular packages, such as `numpy` as "np" and so on? Although `PandasAI` already has [`import_dependency()`](https://github.com/gventuri/pandas-ai/blob/main/pandasai/helpers/_optional.py#L45) util-function, and this logic in theory must have to avoid this problem, this  couldn't work because of (regarding to [the issue](https://github.com/gventuri/pandas-ai/issues/400)) HuggingFace just had returned code using `plt` variable without import statement — just something like `plt.show()`, and this caused `NameError`, since there was no such thing as `plt` in the context.

I've some idea for this cases, when API provider "forgets" to add import-statements. Like, for example, force adding `import <var_name>`  to the code when executing, if `NameError: name <var_name> is not defined` occured for example (btw this wouldn't work with aliases, but anyway can help with some other cases). But i'd like to hear opinion from others first.
@gventuri, @mspronesti welcome to discuss=)

___

* (fix): set `matplot.pyplot` package under "plt" alias in `_get_environment()`

___

- [x] closes #400
- [x] closes #430 
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai#contributing).
