### PR TITLE
Fixing multidataframe bugs when enforcing privacy

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -384,7 +384,7 @@ class PandasAI(Shortcuts):
 
                 if multiple:
                     heads = [
-                        anonymize_dataframe_head(dataframe)
+                        anonymize_dataframe_head(dataframe.head(rows_to_display))
                         if anonymize_df
                         else dataframe.head(rows_to_display)
                         for dataframe in data_frame

--- a/pandasai/prompts/multiple_dataframes.py
+++ b/pandasai/prompts/multiple_dataframes.py
@@ -22,7 +22,6 @@ Using the provided dataframes and no other dataframes, return the python code an
             row, col = dataframe.shape
 
             self.text += f"""
-Dataframe df{i}, with {row} rows and {col} columns.
 This is the metadata of the dataframe df{i}:
 {dataframe}"""
 

--- a/tests/prompts/test_multiple_dataframes_prompt.py
+++ b/tests/prompts/test_multiple_dataframes_prompt.py
@@ -23,7 +23,6 @@ class TestMultipleDataframesPrompt:
             str(MultipleDataframesPrompt(dataframes=[df1, df2]))
             == """
 You are provided with the following pandas dataframes:
-Dataframe df1, with 5 rows and 3 columns.
 This is the metadata of the dataframe df1:
     A  B  C
 0  10  1  2
@@ -31,7 +30,6 @@ This is the metadata of the dataframe df1:
 2  30  3  4
 3  40  4  5
 4  50  5  6
-Dataframe df2, with 5 rows and 3 columns.
 This is the metadata of the dataframe df2:
     A  B  C
 0  10  1  2


### PR DESCRIPTION
Fixing bug which sends the dataframe head when anonymize_df=True in the multidataframe case.

Also fixing bug which tells the model that dataframe has 0 rows when enforce_privacy = True in the multidataframe case.

- [ x ] closes #418 

