### PR TITLE
Update code_manager.py

### DIFF
--- a/pandasai/helpers/code_manager.py
+++ b/pandasai/helpers/code_manager.py
@@ -168,7 +168,7 @@ class CodeManager:
             code = add_save_chart(
                 code,
                 logger=self._logger,
-                folder_name=prompt_id,
+                folder_name=str(prompt_id),
                 save_charts_path=self._config.save_charts_path,
             )
 


### PR DESCRIPTION
- [x] closes #461 
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

https://github.com/gventuri/pandas-ai/issues/461
The source of this error is that when `SmartDataLake` and the likes now create `folder_name` as a `UUID`. But when passing `folder_name` to `save_charts`, it was never converted into a string, thus causing the `TypeError`.

https://github.com/gventuri/pandas-ai/blob/0b69622d5ab22ee9c1194b452f87f3ae292e7fd6/pandasai/smart_datalake/__init__.py#L166
```py
    def _assign_prompt_id(self):
        """Assign a prompt ID"""

        self._last_prompt_id = uuid.uuid4()
        self._logger.log(f"Prompt ID: {self._last_prompt_id}")
```

The prompt_id is then used by:
https://github.com/gventuri/pandas-ai/blob/0b69622d5ab22ee9c1194b452f87f3ae292e7fd6/pandasai/smart_datalake/__init__.py#L292
```py
                    # Execute the code
                    result = self._code_manager.execute_code(
                        code=code_to_run,
                        prompt_id=self._last_prompt_id,
                    )
```

Which calls `code_manager` to execute the code, with `prompt_id` still being an `uuid` type:
https://github.com/gventuri/pandas-ai/blob/0b69622d5ab22ee9c1194b452f87f3ae292e7fd6/pandasai/helpers/code_manager.py#L167
```py
        if self._config.save_charts:
            code = add_save_chart(
                code,
                logger=self._logger,
                folder_name=prompt_id,
                save_charts_path=self._config.save_charts_path,
            )
```

**Fix**: cast `prompt_id` to str().