### PR TITLE
fix: conversion of series output to pandas dataframe

### DIFF
--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -374,7 +374,9 @@ class SmartDatalake:
                     import polars as pl
 
                     df = pl.from_pandas(df)
-
+            if isinstance(df, pd.Series):
+                df = df.to_frame()
+                
             return SmartDataframe(
                 df,
                 config=self._config.__dict__,


### PR DESCRIPTION
Fixes some instances of `ValueError: Invalid input data. Must be a Pandas or Polars dataframe.` 

Takes series output and converts result to polars df

Test before:
![Screenshot 2023-08-22 at 3 23 50 PM](https://github.com/gventuri/pandas-ai/assets/7243933/3bab38c8-2e57-4e7a-9a18-867a74323dda)


Test after:
![Screenshot 2023-08-22 at 3 24 15 PM](https://github.com/gventuri/pandas-ai/assets/7243933/d7757e86-178f-40bd-8b0c-ac1103ed0942)


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).
