### PR TITLE
feat[SmartDataframe]: save dataframe for later use

### DIFF
--- a/pandasai/helpers/df_config_manager.py
+++ b/pandasai/helpers/df_config_manager.py
@@ -1,0 +1,132 @@
+"""
+Class to manage the configuration of the dataframe
+"""
+
+import json
+import os
+import hashlib
+from pandasai.helpers.path import create_directory, find_closest, find_project_root
+from .df_info import df_type
+
+
+class DfConfigManager:
+    """
+    Class to manage the configuration of the dataframe
+    """
+
+    _df = None
+
+    def __init__(self, df):
+        """
+        Args:
+            df (DataFrameType): Pandas or Polars dataframe
+        """
+
+        self._df = df
+
+    def _create_csv_save_path(self):
+        """
+        Creates the path for the csv file to be saved
+        """
+
+        directory_path = os.path.join(find_project_root(), "cache")
+        create_directory(directory_path)
+        csv_file_path = os.path.join(directory_path, f"{self.name}.csv")
+        return csv_file_path
+
+    def _check_for_duplicates(self, saved_dfs):
+        """
+        Checks if the dataframe name already exists
+
+        Args:
+            saved_dfs (List[dict]): List of saved dataframes
+        """
+
+        # Check for duplicates
+        for df_info in saved_dfs:
+            if df_info["name"] == self.name:
+                raise ValueError(f"Duplicate dataframe found: {self.name}")
+
+    def _get_import_path(self):
+        """
+        Gets the import path for the dataframe
+        """
+
+        # Return if already a string
+        if isinstance(self.original_import, str):
+            # Check if it is a csv or xlsx file
+            if self.original_import.endswith(".csv") or self.original_import.endswith(
+                ".xlsx"
+            ):
+                return self.original_import
+
+            # Otherwise, it means it is a dataframe imported from config
+            raise ValueError("Dataframe imported from config cannot be saved")
+
+        # Save df if pandas or polar
+        dataframe_type = df_type(self.original_import)
+        if dataframe_type == "pandas":
+            csv_file_path = self._create_csv_save_path()
+            self._df.original.to_csv(csv_file_path)
+        elif dataframe_type == "polars":
+            csv_file_path = self._create_csv_save_path()
+            with open(csv_file_path, "w") as f:
+                self._df.original.write_csv(f)
+        else:
+            raise ValueError("Unknown dataframe type")
+
+        return csv_file_path
+
+    def save(self):
+        """
+        Saves the dataframe object to used for later
+        """
+
+        file_path = find_closest("pandasai.json")
+
+        # Open config file
+        saved_df_keys = "saved_dfs"
+        with open(file_path, "r") as json_file:
+            pandas_json = json.load(json_file)
+            if saved_df_keys not in pandas_json:
+                pandas_json[saved_df_keys] = []
+
+            # Check for duplicates
+            self._check_for_duplicates(pandas_json[saved_df_keys])
+
+            # Get import path
+            import_path = self._get_import_path()
+
+            pandas_json[saved_df_keys].append(
+                {
+                    "name": self.name,
+                    "description": self.description,
+                    "sample": self.head_csv,
+                    "import_path": import_path,
+                }
+            )
+
+        # Save the output in pandasai.json
+        with open(file_path, "w") as json_file:
+            json.dump(pandas_json, json_file, indent=2)
+
+    @property
+    def head_csv(self):
+        return self._df.head_csv
+
+    @property
+    def name(self):
+        name = self._df.name
+        if name is None:
+            # Generate random hash
+            hash_object = hashlib.sha256(self.head_csv.encode())
+            name = hash_object.hexdigest()
+        return name
+
+    @property
+    def description(self):
+        return self._df.description
+
+    @property
+    def original_import(self):
+        return self._df.original_import

--- a/pandasai/helpers/path.py
+++ b/pandasai/helpers/path.py
@@ -37,6 +37,10 @@ def find_closest(filename):
     return os.path.join(find_project_root(filename), filename)
 
 def create_directory(path):
+ 
     if not os.path.exists(path):
         # Create the directory
-        os.makedirs(path)
+        try:
+             os.makedirs(path)
+        except OSError as e:
+            print(f"Error creating directory: {e}")

--- a/pandasai/helpers/path.py
+++ b/pandasai/helpers/path.py
@@ -43,4 +43,4 @@ def create_directory(path):
         try:
              os.makedirs(path)
         except OSError as e:
-            print(f"Error creating directory: {e}")
+            raise OSError(f"Error creating directory: {e}")

--- a/pandasai/helpers/path.py
+++ b/pandasai/helpers/path.py
@@ -35,3 +35,8 @@ def find_project_root(filename=None):
 
 def find_closest(filename):
     return os.path.join(find_project_root(filename), filename)
+
+def create_directory(path):
+    if not os.path.exists(path):
+        # Create the directory
+        os.makedirs(path)

--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -366,32 +366,32 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
         self._dl.llm = llm
 
     def __create_csv_save_path(self):
-        directory_path = os.path.join(find_project_root(), 'cache')
+        directory_path = os.path.join(find_project_root(), "cache")
         create_directory(directory_path)
         csv_file_path = os.path.join(directory_path, f"{self.name}.csv")
         return csv_file_path
 
     def save(self):
-        '''
-            Saves the dataframe object to used for later
-        '''
+        """
+        Saves the dataframe object to used for later
+        """
         file_path = find_closest("pandasai.json")
-        saved_df_keys = 'saved_dfs'
+        saved_df_keys = "saved_dfs"
 
         # open pandas json file
-        with open(file_path, 'r') as json_file:
+        with open(file_path, "r") as json_file:
             pandas_json = json.load(json_file)
             if saved_df_keys not in pandas_json:
                 pandas_json[saved_df_keys] = []
-            
+
             # Check for duplicates
             for df_info in pandas_json[saved_df_keys]:
-                if df_info['name'] == self.name:
-                    raise ValueError(f'Duplicate dataframe found: {self.name}')
-            
+                if df_info["name"] == self.name:
+                    raise ValueError(f"Duplicate dataframe found: {self.name}")
+
             # throw error if name is null
             if not self.name:
-                raise ValueError(f'No Name provided for dataframe')
+                raise ValueError("No Name provided for dataframe")
 
             import_path = None
 
@@ -402,26 +402,27 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
                 self._df.to_csv(csv_file_path, index=False)
                 import_path = csv_file_path
 
-            elif  dataframe_type == "polars":
+            elif dataframe_type == "polars":
                 csv_file_path = self.__create_csv_save_path()
-                with open(csv_file_path, mode="ab") as f:
+                with open(csv_file_path, "w") as f:
                     self._df.write_csv(f, has_header=False)
                 import_path = csv_file_path
 
-            elif isinstance(self._df , str):
+            elif isinstance(self._df, str):
                 import_path = self._df
-            
-            else:
-                raise ValueError(f'Unknown dataframe type')
 
-            pandas_json[saved_df_keys].append({
-                "name": self.name,
-                "description": self.description,
-                "sample": self.head_csv,
-                "import_path": import_path
-            }
+            else:
+                raise ValueError("Unknown dataframe type")
+
+            pandas_json[saved_df_keys].append(
+                {
+                    "name": self.name,
+                    "description": self.description,
+                    "sample": self.head_csv,
+                    "import_path": import_path,
+                }
             )
-        
+
         # save the output in pandasai.json
-        with open(file_path, 'w') as json_file:
-            json.dump(pandas_json,json_file, indent=4)
+        with open(file_path, "w") as json_file:
+            json.dump(pandas_json, json_file, indent=4)

--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -383,15 +383,15 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
             pandas_json = json.load(json_file)
             if saved_df_keys not in pandas_json:
                 pandas_json[saved_df_keys] = []
-
+            
             # Check for duplicates
             for df_info in pandas_json[saved_df_keys]:
                 if df_info['name'] == self.name:
-                    raise ValueError(f'Duplicate item found: {self.name}')
+                    raise ValueError(f'Duplicate dataframe found: {self.name}')
             
             # throw error if name is null
             if not self.name:
-                raise ValueError(f'No Name provided')
+                raise ValueError(f'No Name provided for dataframe')
 
             import_path = None
 
@@ -425,5 +425,3 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
         # save the output in pandasai.json
         with open(file_path, 'w') as json_file:
             json.dump(pandas_json,json_file, indent=4)
-
-        

--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -365,6 +365,12 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
     def llm(self, llm: Union[LLM, LangchainLLM]):
         self._dl.llm = llm
 
+    def __create_csv_save_path(self):
+        directory_path = os.path.join(find_project_root(), 'cache')
+        create_directory(directory_path)
+        csv_file_path = os.path.join(directory_path, f"{self.name}.csv")
+        return csv_file_path
+
     def save(self):
         '''
             Saves the dataframe object to used for later
@@ -390,11 +396,16 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
             import_path = None
 
             # save df if pandas or polar
-            if df_type(self._df) == "pandas" or df_type(self._df) == "polars":
-                directory_path = os.path.join(find_project_root(), 'cache')
-                create_directory(directory_path)
-                csv_file_path = os.path.join(directory_path, f"{self.name}.csv")
-                self._df.to_csv(csv_file_path)
+            dataframe_type = df_type(self._df)
+            if dataframe_type == "pandas":
+                csv_file_path = self.__create_csv_save_path()
+                self._df.to_csv(csv_file_path, index=False)
+                import_path = csv_file_path
+
+            elif  dataframe_type == "polars":
+                csv_file_path = self.__create_csv_save_path()
+                with open(csv_file_path, mode="ab") as f:
+                    self._df.write_csv(f, has_header=False)
                 import_path = csv_file_path
 
             elif isinstance(self._df , str):

--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -19,8 +19,12 @@ Example:
 """
 
 import hashlib
+import json
+import os
 
 import pandas as pd
+
+from pandasai.helpers.path import create_directory, find_closest, find_project_root
 from ..smart_datalake import SmartDatalake
 from ..helpers.df_config import Config
 from ..helpers.data_sampler import DataSampler
@@ -360,3 +364,55 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
     @llm.setter
     def llm(self, llm: Union[LLM, LangchainLLM]):
         self._dl.llm = llm
+
+    def save(self):
+        '''
+            Saves the dataframe object to used for later
+        '''
+        file_path = find_closest("pandasai.json")
+        saved_df_keys = 'saved_dfs'
+
+        # open pandas json file
+        with open(file_path, 'r') as json_file:
+            pandas_json = json.load(json_file)
+            if saved_df_keys not in pandas_json:
+                pandas_json[saved_df_keys] = []
+
+            # Check for duplicates
+            for df_info in pandas_json[saved_df_keys]:
+                if df_info['name'] == self.name:
+                    raise ValueError(f'Duplicate item found: {self.name}')
+            
+            # throw error if name is null
+            if not self.name:
+                raise ValueError(f'No Name provided')
+
+            import_path = None
+
+            # save df if pandas or polar
+            if df_type(self._df) == "pandas" or df_type(self._df) == "polars":
+                directory_path = os.path.join(find_project_root(), 'cache')
+                create_directory(directory_path)
+                csv_file_path = os.path.join(directory_path, f"{self.name}.csv")
+                self._df.to_csv(csv_file_path)
+                import_path = csv_file_path
+
+            elif isinstance(self._df , str):
+                import_path = self._df
+            
+            else:
+                raise ValueError(f'Unknown dataframe type')
+
+            pandas_json[saved_df_keys].append({
+                "name": self.name,
+                "description": self.description,
+                "sample": self.head_csv,
+                "import_path": import_path
+            }
+            )
+        
+        # save the output in pandasai.json
+        with open(file_path, 'w') as json_file:
+            json.dump(pandas_json,json_file, indent=4)
+
+        

--- a/pandasai/smart_dataframe/abstract_df.py
+++ b/pandasai/smart_dataframe/abstract_df.py
@@ -167,6 +167,3 @@ class DataframeAbstract:
 
     def filter(self, expr):
         raise NotImplementedError
-
-    def save(self):
-        raise NotImplementedError

--- a/pandasai/smart_dataframe/abstract_df.py
+++ b/pandasai/smart_dataframe/abstract_df.py
@@ -167,3 +167,6 @@ class DataframeAbstract:
 
     def filter(self, expr):
         raise NotImplementedError
+
+    def save(self):
+        raise NotImplementedError

--- a/tests/test_smartdataframe.py
+++ b/tests/test_smartdataframe.py
@@ -506,7 +506,6 @@ result = {'happiness': 1, 'gdp': 0.43}```"""
         with open("pandasai.json", 'w') as json_file:
             json.dump(backup_pandasai,json_file, indent=4)
         
-
     def test_save_pandas_dataframe_duplicate_name(self,llm):
         with open("pandasai.json", 'r') as json_file:
             backup_pandasai = json.load(json_file)
@@ -521,20 +520,18 @@ result = {'happiness': 1, 'gdp': 0.43}```"""
         df_object2 = SmartDataframe(df, name='df_duplicate', description='Description 2', 
                                     config={"llm": llm, "enable_cache": False})
 
-        # Call the save function for both instances
-        try:
-            df_object1.save()
-            df_object2.save() 
-            assert True == False 
         
-        except ValueError as e:
-            assert True == True
-        finally:
-             # recover file for next test case
-            with open("pandasai.json", 'w') as json_file:
-                json.dump(backup_pandasai,json_file, indent=4)
-     
+        # Call the save function for the first instance
+        df_object1.save()
 
+        # Attempt to save the second instance and check for ValueError
+        with pytest.raises(ValueError, match="Duplicate dataframe found: df_duplicate"):
+            df_object2.save()
+
+        # Recover file for next test case
+        with open("pandasai.json", 'w') as json_file:
+            json.dump(backup_pandasai,json_file, indent=4)
+    
     def test_save_pandas_no_name(self, llm):
         with open("pandasai.json", 'r') as json_file:
             backup_pandasai = json.load(json_file)
@@ -545,14 +542,10 @@ result = {'happiness': 1, 'gdp': 0.43}```"""
         df_object = SmartDataframe(df, name=None, description='No Name', config={"llm": llm, "enable_cache": False})
 
     
-         # Call the save function for both instances
-        try:
+        # Attempt to save the instance and check for ValueError
+        with pytest.raises(ValueError, match="No Name provided for dataframe"):
             df_object.save()
-            assert True == False 
-        
-        except ValueError as e:
-            assert True == True
-        finally:
-             # recover file for next test case
-            with open("pandasai.json", 'w') as json_file:
-                json.dump(backup_pandasai,json_file, indent=4)
+
+        # Recover file for next test case
+        with open("pandasai.json", 'w') as json_file:
+            json.dump(backup_pandasai,json_file, indent=4)

--- a/tests/test_smartdataframe.py
+++ b/tests/test_smartdataframe.py
@@ -1,4 +1,5 @@
 """Unit tests for the SmartDatalake class"""
+import json
 import sys
 from typing import Optional
 from unittest.mock import patch, Mock
@@ -461,3 +462,97 @@ result = {'happiness': 1, 'gdp': 0.43}```"""
 
         assert isinstance(smart_dataframe._df, pd.DataFrame)
         assert smart_dataframe._df.equals(pd.DataFrame({0: [1, 2, 3]}))
+
+    def test_save_pandas_dataframe(self,  llm):
+
+        with open("pandasai.json", 'r') as json_file:
+            backup_pandasai = json.load(json_file)
+        
+        # Create an instance of SmartDataframe
+        df_object = SmartDataframe(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
+                                    name='df_test', description='Test description', config={"llm": llm, "enable_cache": False})
+
+        # Call the save function
+        df_object.save()
+
+        # Verify that the data was saved correctly
+        with open("pandasai.json", 'r') as json_file:
+            data = json.load(json_file)
+            assert data['saved_dfs'][0]['name'] == 'df_test'
+        
+        with open("pandasai.json", 'w') as json_file:
+            json.dump(backup_pandasai,json_file, indent=4)
+    
+    def test_save_polars_dataframe(self, llm):
+
+        with open("pandasai.json", 'r') as json_file:
+            backup_pandasai = json.load(json_file)
+
+        # Create an instance of SmartDataframe
+        polars_df = pl.DataFrame({"column1": [1, 2, 3], "column2": [4, 5, 6]})
+
+        df_object = SmartDataframe(polars_df,
+                                    name='df_test_polar', description='Test description', config={"llm": llm, "enable_cache": False})
+
+        # Call the save function
+        df_object.save()
+
+        # Verify that the data was saved correctly
+        with open("pandasai.json", 'r') as json_file:
+            data = json.load(json_file)
+            assert data['saved_dfs'][0]['name'] == 'df_test_polar'
+        
+        # recover file for next test case
+        with open("pandasai.json", 'w') as json_file:
+            json.dump(backup_pandasai,json_file, indent=4)
+        
+
+    def test_save_pandas_dataframe_duplicate_name(self,llm):
+        with open("pandasai.json", 'r') as json_file:
+            backup_pandasai = json.load(json_file)
+
+        # Create a sample DataFrame
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+        
+        # Create instances of YourDataFrameClass
+        df_object1 = SmartDataframe(df, 
+                                    name='df_duplicate', description='Description 1', 
+                                    config={"llm": llm, "enable_cache": False})
+        df_object2 = SmartDataframe(df, name='df_duplicate', description='Description 2', 
+                                    config={"llm": llm, "enable_cache": False})
+
+        # Call the save function for both instances
+        try:
+            df_object1.save()
+            df_object2.save() 
+            assert True == False 
+        
+        except ValueError as e:
+            assert True == True
+        finally:
+             # recover file for next test case
+            with open("pandasai.json", 'w') as json_file:
+                json.dump(backup_pandasai,json_file, indent=4)
+     
+
+    def test_save_pandas_no_name(self, llm):
+        with open("pandasai.json", 'r') as json_file:
+            backup_pandasai = json.load(json_file)
+        # Create a sample DataFrame
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+        
+        # Create an instance of YourDataFrameClass without a name
+        df_object = SmartDataframe(df, name=None, description='No Name', config={"llm": llm, "enable_cache": False})
+
+    
+         # Call the save function for both instances
+        try:
+            df_object.save()
+            assert True == False 
+        
+        except ValueError as e:
+            assert True == True
+        finally:
+             # recover file for next test case
+            with open("pandasai.json", 'w') as json_file:
+                json.dump(backup_pandasai,json_file, indent=4)


### PR DESCRIPTION
- [x] closes #[490](https://github.com/gventuri/pandas-ai/issues/490) 
- [x] Tests converage in progress
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a `save()` method to the `SmartDataframe` class, allowing users to save their dataframe objects for later use. This includes support for both Pandas and Polars dataframes.
- New Feature: Introduced a `DfConfigManager` class that manages the configuration of a dataframe, including creating save paths and checking for duplicates.
- Test: Added new test cases to verify the functionality of the `save()` method in various scenarios, such as handling duplicate dataframe names and saving without a name.
- Chore: Added a `create_directory(path)` function in `pandasai/helpers/path.py` to create directories if they don't exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->