### PR TITLE
fix: non-mutable default params

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -33,7 +33,7 @@ Example:
 
     ```
 """
-
+import warnings
 from typing import List, Optional, Union, Dict, Type
 import importlib.metadata
 
@@ -101,19 +101,19 @@ class PandasAI:
     _config: Config
 
     def __init__(
-        self,
-        llm=None,
-        conversational=False,
-        verbose=False,
-        enforce_privacy=False,
-        save_charts=False,
-        save_charts_path="",
-        enable_cache=True,
-        middlewares=[],
-        custom_whitelisted_dependencies=[],
-        enable_logging=True,
-        non_default_prompts: Optional[Dict[str, Type[Prompt]]] = None,
-        callback: Optional[BaseCallback] = None,
+            self,
+            llm=None,
+            conversational=False,
+            verbose=False,
+            enforce_privacy=False,
+            save_charts=False,
+            save_charts_path="",
+            enable_cache=True,
+            middlewares=None,
+            custom_whitelisted_dependencies=None,
+            enable_logging=True,
+            non_default_prompts: Optional[Dict[str, Type[Prompt]]] = None,
+            callback: Optional[BaseCallback] = None,
     ):
         """
         __init__ method of the Class PandasAI
@@ -142,6 +142,9 @@ class PandasAI:
         # noinspection PyArgumentList
         # https://stackoverflow.com/questions/61226587/pycharm-does-not-recognize-logging-basicconfig-handlers-argument
 
+        warnings.warn("`PandasAI` (class) is deprecated since v1.0 and will be removed "
+                      "in a future release. Please use `SmartDataframe` instead.")
+
         self._config = Config(
             conversational=conversational,
             verbose=verbose,
@@ -149,8 +152,8 @@ class PandasAI:
             save_charts=save_charts,
             save_charts_path=save_charts_path,
             enable_cache=enable_cache,
-            middlewares=middlewares,
-            custom_whitelisted_dependencies=custom_whitelisted_dependencies,
+            middlewares=middlewares or [],
+            custom_whitelisted_dependencies=custom_whitelisted_dependencies or [],
             enable_logging=enable_logging,
             non_default_prompts=non_default_prompts,
             llm=llm,
@@ -158,12 +161,12 @@ class PandasAI:
         )
 
     def run(
-        self,
-        data_frame: Union[pd.DataFrame, List[pd.DataFrame]],
-        prompt: str,
-        show_code: bool = False,
-        anonymize_df: bool = True,
-        use_error_correction_framework: bool = True,
+            self,
+            data_frame: Union[pd.DataFrame, List[pd.DataFrame]],
+            prompt: str,
+            show_code: bool = False,
+            anonymize_df: bool = True,
+            use_error_correction_framework: bool = True,
     ) -> Union[str, pd.DataFrame]:
         """
         Run the PandasAI to make Dataframes Conversational.
@@ -195,12 +198,12 @@ class PandasAI:
         return self._dl.chat(prompt)
 
     def __call__(
-        self,
-        data_frame: Union[pd.DataFrame, List[pd.DataFrame]],
-        prompt: str,
-        show_code: bool = False,
-        anonymize_df: bool = True,
-        use_error_correction_framework: bool = True,
+            self,
+            data_frame: Union[pd.DataFrame, List[pd.DataFrame]],
+            prompt: str,
+            show_code: bool = False,
+            anonymize_df: bool = True,
+            use_error_correction_framework: bool = True,
     ) -> Union[str, pd.DataFrame]:
         """
         __call__ method of PandasAI class. It calls the `run` method.

--- a/pandasai/schemas/df_config.py
+++ b/pandasai/schemas/df_config.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, validator
-from typing import List, Optional, Any
+from pydantic import BaseModel, validator, Field
+from typing import Optional, List, Any, Dict
 from ..middlewares.base import Middleware
 from ..callbacks.base import BaseCallback
 from ..llm import LLM, LangchainLLM
@@ -12,12 +12,12 @@ class Config(BaseModel):
     enforce_privacy: bool = False
     enable_cache: bool = True
     use_error_correction_framework: bool = True
-    custom_prompts: dict = {}
+    custom_prompts: Dict = Field(default_factory=dict)
     save_charts: bool = False
     save_charts_path: str = "exports/charts"
-    custom_whitelisted_dependencies: List[str] = []
+    custom_whitelisted_dependencies: List[str] = Field(default_factory=list)
     max_retries: int = 3
-    middlewares: List[Middleware] = []
+    middlewares: List[Middleware] = Field(default_factory=list)
     callback: Optional[BaseCallback] = None
     llm: Any = None
 


### PR DESCRIPTION
Hi @gventuri,
this PR aims at
- addressing #503 
- removing some mutable defaults (leftovers, I suppose) and replacing them with pydantic `Field` with `default_factory`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Refactor: 
- Deprecated the `PandasAI` class in `pandasai/__init__.py`. Users are advised to migrate to the new implementation.
- Improved type hinting and default values in `pandasai/schemas/df_config.py` for better usability and error prevention. The `Config` class now provides default factories for `custom_prompts`, `custom_whitelisted_dependencies`, and `middlewares` attributes."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->