### PR TITLE
Deprecate Falcon and Starcoder

### DIFF
--- a/docs/API/llms.md
+++ b/docs/API/llms.md
@@ -18,17 +18,21 @@ OpenAI API wrapper extended through BaseOpenAI class.
 options:
 show_root_heading: true
 
-### Starcoder
+### Starcoder (deprecated)
 
 Starcoder wrapper extended through Base HuggingFace Class
+
+- Note: Starcoder is deprecated and will be removed in future versions. Please use another LLM.
 
 ::: pandasai.llm.starcoder
 options:
 show_root_heading: true
 
-### Falcon
+### Falcon (deprecated)
 
 Falcon wrapper extended through Base HuggingFace Class
+
+- Note: Falcon is deprecated and will be removed in future versions. Please use another LLM.
 
 ::: pandasai.llm.falcon
 options:

--- a/pandasai/llm/falcon.py
+++ b/pandasai/llm/falcon.py
@@ -8,7 +8,7 @@ Example:
 
     >>> from pandasai.llm.falcon import Falcon
 """
-
+import warnings
 
 from ..helpers import load_dotenv
 from .base import HuggingFaceLLM
@@ -17,18 +17,22 @@ load_dotenv()
 
 
 class Falcon(HuggingFaceLLM):
-
-    """Falcon LLM API
-
-    A base HuggingFaceLLM class is extended to use Falcon model.
-
-    """
+    """Falcon LLM API (Deprecated: Kept for backwards compatibility)"""
 
     api_token: str
     _api_url: str = (
         "https://api-inference.huggingface.co/models/tiiuae/falcon-7b-instruct"
     )
     _max_retries: int = 30
+
+    def __init__(self, **kwargs):
+        warnings.warn(
+            """Falcon is deprecated and will be removed in a future release.
+            Please use langchain.llms.HuggingFaceHub instead, although please be 
+            aware that it may perform poorly.
+            """
+        )
+        super().__init__(**kwargs)
 
     @property
     def type(self) -> str:

--- a/pandasai/llm/starcoder.py
+++ b/pandasai/llm/starcoder.py
@@ -8,7 +8,7 @@ Example:
 
     >>> from pandasai.llm.starcoder import Starcoder
 """
-
+import warnings
 
 from ..helpers import load_dotenv
 from .base import HuggingFaceLLM
@@ -18,15 +18,20 @@ load_dotenv()
 
 class Starcoder(HuggingFaceLLM):
 
-    """Starcoder LLM API
-
-    A base HuggingFaceLLM class is extended to use Starcoder model.
-
-    """
+    """Starcoder LLM API (Deprecated: Kept for backwards compatibility)"""
 
     api_token: str
     _api_url: str = "https://api-inference.huggingface.co/models/bigcode/starcoder"
     _max_retries: int = 30
+
+    def __init__(self, **kwargs):
+        warnings.warn(
+            """Starcoder is deprecated and will be removed in a future release.
+            Please use langchain.llms.HuggingFaceHub instead, although please be 
+            aware that it may perform poorly.
+            """
+        )
+        super().__init__(**kwargs)
 
     @property
     def type(self) -> str:


### PR DESCRIPTION
Hi @gventuri,
as a result of this discussion #525, this PR aims at deprecating Falcon and Starcoder. Not sure we should update the docs yet.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Deprecated the `Falcon` and `Starcoder` classes in the `pandasai/llm` module. Users are advised to use the `langchain.llms.HuggingFaceHub` class instead for future projects.
- Documentation: Updated the API documentation (`docs/API/llms.md`) to reflect these deprecations and provide guidance on the recommended alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->