### PR TITLE
Add openai key path

### DIFF
--- a/pandasai/llm/openai.py
+++ b/pandasai/llm/openai.py
@@ -49,6 +49,7 @@ class OpenAI(BaseOpenAI):
     def __init__(
         self,
         api_token: Optional[str] = None,
+        api_key_path: Optional[str] = None
         **kwargs,
     ):
         """
@@ -59,11 +60,18 @@ class OpenAI(BaseOpenAI):
             **kwargs: Extended Parameters inferred from BaseOpenAI class
 
         """
-
         self.api_token = api_token or os.getenv("OPENAI_API_KEY") or None
-        if self.api_token is None:
-            raise APIKeyNotFoundError("OpenAI API key is required")
-        openai.api_key = self.api_token
+        self.api_key_path = api_key_path
+
+        if (not self.api_token) and (not self.api_key_path):
+            raise APIKeyNotFoundError(
+                "Either OpenAI API key or key path is required"
+            )
+        
+        if self.api_token:
+            openai.api_key = self.api_token
+        else:
+            openai.api_key_path = self.api_key_path
 
         self.openai_proxy = kwargs.get("openai_proxy") or os.getenv("OPENAI_PROXY")
         if self.openai_proxy:

--- a/pandasai/llm/openai.py
+++ b/pandasai/llm/openai.py
@@ -49,7 +49,7 @@ class OpenAI(BaseOpenAI):
     def __init__(
         self,
         api_token: Optional[str] = None,
-        api_key_path: Optional[str] = None
+        api_key_path: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -64,10 +64,8 @@ class OpenAI(BaseOpenAI):
         self.api_key_path = api_key_path
 
         if (not self.api_token) and (not self.api_key_path):
-            raise APIKeyNotFoundError(
-                "Either OpenAI API key or key path is required"
-            )
-        
+            raise APIKeyNotFoundError("Either OpenAI API key or key path is required")
+
         if self.api_token:
             openai.api_key = self.api_token
         else:

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -24,6 +24,9 @@ class TestOpenAILLM:
 
     def test_type_with_token(self):
         assert OpenAI(api_token="test").type == "openai"
+    
+    def test_type_with_key_path(self):
+        assert OpenAI(api_key_file=".key").type == "openai"
 
     def test_proxy(self):
         proxy = "http://proxy.mycompany.com:8080"

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -24,9 +24,9 @@ class TestOpenAILLM:
 
     def test_type_with_token(self):
         assert OpenAI(api_token="test").type == "openai"
-    
+
     def test_type_with_key_path(self):
-        assert OpenAI(api_key_file=".key").type == "openai"
+        assert OpenAI(api_key_path=".key").type == "openai"
 
     def test_proxy(self):
         proxy = "http://proxy.mycompany.com:8080"


### PR DESCRIPTION
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

Currently `llm.OpenAI` only accepts `api_key` where as `openai` module provides additional function of passing `api_key_path` which ensures `api_key` is read from this file. 

This might be beneficial, if you are using `PandasAI` together with native `openai` workflows because of option of defining `openai_key_file` parameter once and both libraries using this path. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced an optional parameter `api_key_path` to the `OpenAI` class in `pandasai/llm/openai.py`. This allows users to provide a path to their OpenAI API key file, offering an alternative to directly using the `api_token`.
- Test: Added a new test case `test_type_with_key_path` in `tests/llms/test_openai.py` to ensure that when `api_key_path` is provided, the `type` attribute of the `OpenAI` instance is correctly set to "openai".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->