### PR TITLE
fix: broken link to llms.md page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,8 +114,8 @@ As an alternative, you can simply edit the `pandasai.json` file in the root of y
 
 Settings:
 
-- `llm`: the LLM to use. You can pass an instance of an LLM or the name of an LLM. You can use one of the LLMs supported. You can find more information about LLMs [here](llms.md).
-- `llm_options`: the options to use for the LLM (for example the api token, etc). You can find more information about the settings [here](llms.md).
+- `llm`: the LLM to use. You can pass an instance of an LLM or the name of an LLM. You can use one of the LLMs supported. You can find more information about LLMs [here](./LLMs/llms.md).
+- `llm_options`: the options to use for the LLM (for example the api token, etc). You can find more information about the settings [here](./LLMs/llms.md).
 - `save_logs`: whether to save the logs of the LLM. Defaults to `True`. You will find the logs in the `pandasai.log` file in the root of your project.
 - `verbose`: whether to print the logs in the console as PandasAI is executed. Defaults to `False`.
 - `enforce_privacy`: whether to enforce privacy. Defaults to `False`. If set to `True`, PandasAI will not send any data to the LLM, but only the metadata. By default, PandasAI will send 5 samples that are anonymized to improve the accuracy of the results.


### PR DESCRIPTION
- [ ] closes  #575
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

On the "getting-started.md" page I corrected the two broken hyperlinks to the same llms.md page. The correct location is now under the "LLMs" directory. 

<img width="797" alt="Screenshot 2023-09-19 204930" src="https://github.com/gventuri/pandas-ai/assets/31699450/a8430a76-0428-453b-94e1-4e567ea07299">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Documentation: Updated the paths for documentation links related to LLMs in `pandasai.json`. The new paths now include a subdirectory called "LLMs" before the filename, improving the organization and accessibility of our documentation resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->