### PR TITLE
docs: docsting for `call()` in `BaseGoogle` LLM

### DIFF
--- a/pandasai/llm/base.py
+++ b/pandasai/llm/base.py
@@ -475,9 +475,8 @@ class BaseGoogle(LLM):
         Call the Google LLM.
 
         Args:
-            instruction (object): Instruction to pass
-            value (str): Value to pass
-            suffix (str): Suffix to pass
+            instruction (Prompt): Instruction to pass.
+            suffix (str): Suffix to pass. Defaults to an empty string ("").
 
         Returns:
             str: LLM response.


### PR DESCRIPTION
An agrument called `value` seems to be deprecated in current version for Google LLMs classes (it was added in baedcbcef2571bb55d85cefc090fe8de2429ecfa). Remove the docsting.
Update docstrings for `instruction` (too general type `object` was specified, this mismatches type hints). 
Update docstrings for `suffix`.

___

* (docs): remove an argument description deprecated for the deprecated `value` argument
* (docs): change type for `instruction`
* (docs): make `suffix` description to look more verbose

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the `call` method in the base class of the `pandasai/llm/base.py` file. The changes include removal of the `value` parameter and modification of the `suffix` parameter's default value. Additionally, the `instruction` parameter has been annotated with the type `Prompt`. These changes streamline the function signature and enhance code readability without altering the core functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->