### PR TITLE
docs: rename custom opt. dep-s docfile (#581)

### DIFF
--- a/docs/custom-whitelisted-dependencies.md
+++ b/docs/custom-whitelisted-dependencies.md
@@ -1,4 +1,4 @@
-# Custom optional dependencies
+# Custom whitelisted dependencies
 
 By default, PandasAI only allows to run code that uses some whitelisted modules. This is to prevent malicious code from being executed on the server or locally. However, it is possible to add custom modules to the whitelist. This can be done by passing a list of modules to the `custom_whitelisted_dependencies` parameter when instantiating the `SmartDataframe` or `SmartDatalake` class.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
       - middlewares.md
       - callbacks.md
       - custom-prompts.md
-      - custom-optional-dependencies.md
+      - custom-whitelisted-dependencies.md
   - Examples:
       - examples.md
   - Command Line Tool:


### PR DESCRIPTION
Minor fixes in documentation files for #581.

___

* (fix): link for custom-whitelisted-dependencies.md now works as it suppose to be
* (chore): update mkdocs.yml with a new filename

- [x] closes #581
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Renamed "Custom optional dependencies" to "Custom whitelisted dependencies" across the codebase for improved clarity.
- Documentation: Updated `custom-whitelisted-dependencies.md` to explain the new terminology and usage. Users can now add custom modules to the whitelist by passing them to the `custom_whitelisted_dependencies` parameter when creating instances of `SmartDataframe` or `SmartDatalake`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->