### PR TITLE
refactor: move prompt templates to files (#593)

### DIFF
--- a/assets/prompt-templates/correct_error_prompt.tmpl
+++ b/assets/prompt-templates/correct_error_prompt.tmpl
@@ -1,0 +1,15 @@
+
+You are provided with the following {engine} DataFrames with the following metadata:
+
+{dataframes}
+
+The user asked the following question:
+{conversation}
+
+You generated this python code:
+{code}
+
+It fails with the following error:
+{error_returned}
+
+Correct the python code and return a new python code (do not import anything) that fixes the above mentioned error. Do not generate the same code again.

--- a/assets/prompt-templates/generate_python_code.tmpl
+++ b/assets/prompt-templates/generate_python_code.tmpl
@@ -1,5 +1,4 @@
-""" Prompt to generate Python code
-```
+
 You are provided with the following pandas DataFrames:
 
 {dataframes}
@@ -14,7 +13,7 @@ This is the initial python code to be updated:
 {default_import}
 
 def analyze_data(dfs: list[{engine_df_name}]) -> dict:
-    \"\"\"
+    """
     Analyze the data
     1. Prepare: Preprocessing and cleaning data if necessary
     2. Process: Manipulating data for analysis (grouping, filtering, aggregating, etc.)
@@ -23,29 +22,9 @@ def analyze_data(dfs: list[{engine_df_name}]) -> dict:
     - type (possible values "text", "number", "dataframe", "plot")
     - value (can be a string, a dataframe or the path of the plot, NOT a dictionary)
     Example output: {{ "type": "text", "value": "The average loan amount is $15,000." }}
-    \"\"\"
+    """
 ```
 
 Using the provided dataframes (`dfs`), update the python code based on the last question in the conversation.
-{conversation}
 
 Updated code:
-"""  # noqa: E501
-
-
-from .base import FileBasedPrompt
-
-
-class GeneratePythonCodeAbstractPrompt(FileBasedPrompt):
-    """Prompt to generate Python code"""
-
-    _path_to_template = "assets/prompt-templates/generate_python_code.tmpl"
-
-    def __init__(self, **kwargs):
-        default_import = "import pandas as pd"
-        engine_df_name = "pd.DataFrame"
-
-        self.set_var("default_import", default_import)
-        self.set_var("engine_df_name", engine_df_name)
-
-        super().__init__(**kwargs)

--- a/docs/custom-prompts.md
+++ b/docs/custom-prompts.md
@@ -20,12 +20,39 @@ from pandasai.prompts import AbstractPrompt
 
 
 class MyCustomPrompt(AbstractPrompt):
-    template = """This is your custom text for your prompt with custom {my_custom_value}"""
+    @property
+    def template(self):
+        return """This is your custom text for your prompt with custom {my_custom_value}"""
 
 
 df = SmartDataframe("data.csv", {
     "custom_prompts": {
         "generate_python_code": MyCustomPrompt(
+            my_custom_value="my custom value")
+    }
+})
+```
+
+You can also use `FileBasedPrompt` in case you prefer to store prompt template in a file:
+
+_my_prompt_template.tmpl:_
+```
+This is your custom text for your prompt with custom {my_custom_value}
+```
+_python code:_
+
+```python
+from pandasai import SmartDataframe
+from pandasai.prompts import FileBasedPrompt
+
+
+class MyCustomFileBasedPrompt(FileBasedPrompt):
+    _path_to_template = "path/to/my_prompt_template.tmpl"
+
+
+df = SmartDataframe("data.csv", {
+    "custom_prompts": {
+        "generate_python_code": MyCustomFileBasedPrompt(
             my_custom_value="my custom value")
     }
 })

--- a/docs/custom-prompts.md
+++ b/docs/custom-prompts.md
@@ -16,14 +16,17 @@ To create your custom prompt create a new CustomPromptClass inherited from base 
 
 ```python
 from pandasai import SmartDataframe
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 
-class MyCustomPrompt(Prompt):
-    text = """This is your custom text for your prompt with custom {my_custom_value}"""
+
+class MyCustomPrompt(AbstractPrompt):
+    template = """This is your custom text for your prompt with custom {my_custom_value}"""
+
 
 df = SmartDataframe("data.csv", {
     "custom_prompts": {
-        "generate_python_code": MyCustomPrompt(my_custom_value="my custom value")
+        "generate_python_code": MyCustomPrompt(
+            my_custom_value="my custom value")
     }
 })
 ```
@@ -36,14 +39,16 @@ You can directly access the default prompt variables (for example dfs, conversat
 
 ```python
 from pandasai import SmartDataframe
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 
-class MyCustomPrompt(Prompt):
-    text = """You are given a dataframe with number if rows equal to {dfs[0].shape[0]} and number of columns equal to {dfs[0].shape[1]}
+
+class MyCustomPrompt(AbstractPrompt):
+    template = """You are given a dataframe with number if rows equal to {dfs[0].shape[0]} and number of columns equal to {dfs[0].shape[1]}
 
 Here's the conversation:
 {conversation}
 """
+
 
 df = SmartDataframe("data.csv", {
     "custom_prompts": {

--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -40,7 +40,7 @@ import importlib.metadata
 import pandas as pd
 from .smart_dataframe import SmartDataframe
 from .smart_datalake import SmartDatalake
-from .prompts.base import Prompt
+from .prompts.base import AbstractPrompt
 from .callbacks.base import BaseCallback
 from .schemas.df_config import Config
 from .helpers.cache import Cache
@@ -112,7 +112,7 @@ class PandasAI:
         middlewares=None,
         custom_whitelisted_dependencies=None,
         enable_logging=True,
-        non_default_prompts: Optional[Dict[str, Type[Prompt]]] = None,
+        non_default_prompts: Optional[Dict[str, Type[AbstractPrompt]]] = None,
         callback: Optional[BaseCallback] = None,
     ):
         """

--- a/pandasai/exceptions.py
+++ b/pandasai/exceptions.py
@@ -71,3 +71,23 @@ class BadImportError(Exception):
             f"Generated code includes import of {library_name} which"
             " is not in whitelist."
         )
+
+
+class TemplateFileNotFoundError(FileNotFoundError):
+    """
+    Raised when a library not in the whitelist is imported.
+    """
+
+    def __init__(self, template_path, prompt_name="Unknown"):
+        """
+        __init__ method of TemplateFileNotFoundError Class
+
+        Args:
+            template_path (str): Path for template file.
+            prompt_name (str): Prompt name. Defaults to "Unknown".
+        """
+        self.template_path = template_path
+        super().__init__(
+            f"Unable to find a file with template at '{template_path}' "
+            f"for '{prompt_name}' prompt."
+        )

--- a/pandasai/exceptions.py
+++ b/pandasai/exceptions.py
@@ -75,7 +75,7 @@ class BadImportError(Exception):
 
 class TemplateFileNotFoundError(FileNotFoundError):
     """
-    Raised when a library not in the whitelist is imported.
+    Raised when a template file cannot be found.
     """
 
     def __init__(self, template_path, prompt_name="Unknown"):

--- a/pandasai/helpers/from_google_sheets.py
+++ b/pandasai/helpers/from_google_sheets.py
@@ -26,7 +26,7 @@ def get_google_sheet(src) -> list:
         cols = row.find_all("td")
         clean_row = []
         for col in cols:
-            clean_row.append(col.text)
+            clean_row.append(col.template)
         grid.append(clean_row)
     return grid
 

--- a/pandasai/helpers/from_google_sheets.py
+++ b/pandasai/helpers/from_google_sheets.py
@@ -26,7 +26,7 @@ def get_google_sheet(src) -> list:
         cols = row.find_all("td")
         clean_row = []
         for col in cols:
-            clean_row.append(col.template)
+            clean_row.append(col.text)
         grid.append(clean_row)
     return grid
 

--- a/pandasai/llm/azure_openai.py
+++ b/pandasai/llm/azure_openai.py
@@ -18,7 +18,7 @@ import openai
 from ..helpers import load_dotenv
 
 from ..exceptions import APIKeyNotFoundError, UnsupportedOpenAIModelError
-from ..prompts.base import Prompt
+from ..prompts.base import AbstractPrompt
 from .base import BaseOpenAI
 
 load_dotenv()
@@ -105,12 +105,12 @@ class AzureOpenAI(BaseOpenAI):
         """
         return {**super()._default_params, "engine": self.engine}
 
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         """
         Call the Azure OpenAI LLM.
 
         Args:
-            instruction (Prompt): A prompt object with instruction for LLM.
+            instruction (AbstractPrompt): A prompt object with instruction for LLM.
             suffix (str): Suffix to pass.
 
         Returns:

--- a/pandasai/llm/base.py
+++ b/pandasai/llm/base.py
@@ -29,7 +29,7 @@ from ..exceptions import (
     NoCodeFoundError,
 )
 from ..helpers.openai_info import openai_callback_var
-from ..prompts.base import Prompt
+from ..prompts.base import AbstractPrompt
 
 
 class LLM:
@@ -120,12 +120,12 @@ class LLM:
         return code
 
     @abstractmethod
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         """
         Execute the LLM with given prompt.
 
         Args:
-            instruction (Prompt): A prompt object with instruction for LLM.
+            instruction (AbstractPrompt): A prompt object with instruction for LLM.
             suffix (str, optional): Suffix. Defaults to "".
 
         Raises:
@@ -134,12 +134,12 @@ class LLM:
         """
         raise MethodNotImplementedError("Call method has not been implemented")
 
-    def generate_code(self, instruction: Prompt) -> str:
+    def generate_code(self, instruction: AbstractPrompt) -> str:
         """
         Generate the code based on the instruction and the given prompt.
 
         Args:
-            instruction (Prompt): Prompt with instruction for LLM.
+            instruction (AbstractPrompt): Prompt with instruction for LLM.
 
         Returns:
             str: A string of Python code.
@@ -334,11 +334,11 @@ class HuggingFaceLLM(LLM):
 
         return response.json()[0]["generated_text"]
 
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         """
         A call method of HuggingFaceLLM class.
         Args:
-            instruction (Prompt): A prompt object with instruction for LLM.
+            instruction (AbstractPrompt): A prompt object with instruction for LLM.
             suffix (str): A string representing the suffix to be truncated
                 from the generated response.
 
@@ -429,12 +429,12 @@ class BaseGoogle(LLM):
         """
         raise MethodNotImplementedError("method has not been implemented")
 
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         """
         Call the Google LLM.
 
         Args:
-            instruction (Prompt): Instruction to pass.
+            instruction (AbstractPrompt): Instruction to pass.
             suffix (str): Suffix to pass. Defaults to an empty string ("").
 
         Returns:

--- a/pandasai/llm/fake.py
+++ b/pandasai/llm/fake.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from ..prompts.base import Prompt
+from ..prompts.base import AbstractPrompt
 from .base import LLM
 
 
@@ -16,7 +16,7 @@ class FakeLLM(LLM):
         if output is not None:
             self._output = output
 
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         self.last_prompt = instruction.to_string() + suffix
         return self._output
 

--- a/pandasai/llm/huggingface_text_gen.py
+++ b/pandasai/llm/huggingface_text_gen.py
@@ -2,7 +2,7 @@ from typing import Optional, Any, List, Dict
 
 from .base import LLM
 from ..helpers import load_dotenv
-from ..prompts.base import Prompt
+from ..prompts.base import AbstractPrompt
 
 load_dotenv()
 
@@ -14,7 +14,7 @@ class HuggingFaceTextGen(LLM):
     top_k: Optional[int] = None
     top_p: Optional[float] = 0.8
     typical_p: Optional[float] = 0.8
-    temperature: float = 1E-3  # must be strictly positive
+    temperature: float = 1e-3  # must be strictly positive
     repetition_penalty: Optional[float] = None
     truncate: Optional[int] = None
     stop_sequences: List[str] = None
@@ -29,7 +29,7 @@ class HuggingFaceTextGen(LLM):
         try:
             import text_generation
 
-            for (key, val) in kwargs.items():
+            for key, val in kwargs.items():
                 if key in self.__annotations__:
                     setattr(self, key, val)
 
@@ -60,14 +60,14 @@ class HuggingFaceTextGen(LLM):
             "seed": self.seed,
         }
 
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         prompt = instruction.to_string() + suffix
 
         params = self._default_params
         if self.streaming:
             completion = ""
             for chunk in self.client.generate_stream(prompt, **params):
-                completion += chunk.text
+                completion += chunk.template
             return completion
 
         res = self.client.generate(prompt, **params)
@@ -76,8 +76,8 @@ class HuggingFaceTextGen(LLM):
             for stop_seq in self.stop_sequences:
                 if stop_seq in res.generated_text:
                     res.generated_text = res.generated_text[
-                                         :res.generated_text.index(stop_seq)
-                                         ]
+                        : res.generated_text.index(stop_seq)
+                    ]
         return res.generated_text
 
     @property

--- a/pandasai/llm/langchain.py
+++ b/pandasai/llm/langchain.py
@@ -1,4 +1,4 @@
-from pandasai.prompts.base import Prompt
+from pandasai.prompts.base import AbstractPrompt
 from .base import LLM
 
 
@@ -13,7 +13,7 @@ class LangchainLLM(LLM):
     def __init__(self, langchain_llm):
         self._langchain_llm = langchain_llm
 
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         prompt = instruction.to_string() + suffix
         return self._langchain_llm.predict(prompt)
 

--- a/pandasai/llm/openai.py
+++ b/pandasai/llm/openai.py
@@ -15,7 +15,7 @@ import openai
 from ..helpers import load_dotenv
 
 from ..exceptions import APIKeyNotFoundError, UnsupportedOpenAIModelError
-from ..prompts.base import Prompt
+from ..prompts.base import AbstractPrompt
 from .base import BaseOpenAI
 
 load_dotenv()
@@ -85,12 +85,12 @@ class OpenAI(BaseOpenAI):
             "model": self.model,
         }
 
-    def call(self, instruction: Prompt, suffix: str = "") -> str:
+    def call(self, instruction: AbstractPrompt, suffix: str = "") -> str:
         """
         Call the OpenAI LLM.
 
         Args:
-            instruction (Prompt): A prompt object with instruction for LLM.
+            instruction (AbstractPrompt): A prompt object with instruction for LLM.
             suffix (str): Suffix to pass.
 
         Raises:

--- a/pandasai/prompts/__init__.py
+++ b/pandasai/prompts/__init__.py
@@ -1,9 +1,9 @@
-from .base import Prompt
-from .correct_error_prompt import CorrectErrorPrompt
-from .generate_python_code import GeneratePythonCodePrompt
+from .base import AbstractPrompt
+from .correct_error_prompt import CorrectErrorAbstractPrompt
+from .generate_python_code import GeneratePythonCodeAbstractPrompt
 
 __all__ = [
-    "Prompt",
-    "CorrectErrorPrompt",
-    "GeneratePythonCodePrompt",
+    "AbstractPrompt",
+    "CorrectErrorAbstractPrompt",
+    "GeneratePythonCodeAbstractPrompt",
 ]

--- a/pandasai/prompts/__init__.py
+++ b/pandasai/prompts/__init__.py
@@ -1,9 +1,9 @@
 from .base import AbstractPrompt
-from .correct_error_prompt import CorrectErrorAbstractPrompt
-from .generate_python_code import GeneratePythonCodeAbstractPrompt
+from .correct_error_prompt import CorrectErrorPrompt
+from .generate_python_code import GeneratePythonCodePrompt
 
 __all__ = [
     "AbstractPrompt",
-    "CorrectErrorAbstractPrompt",
-    "GeneratePythonCodeAbstractPrompt",
+    "CorrectErrorPrompt",
+    "GeneratePythonCodePrompt",
 ]

--- a/pandasai/prompts/__init__.py
+++ b/pandasai/prompts/__init__.py
@@ -1,4 +1,4 @@
-from .base import AbstractPrompt
+from .base import AbstractPrompt, FileBasedPrompt
 from .correct_error_prompt import CorrectErrorPrompt
 from .generate_python_code import GeneratePythonCodePrompt
 
@@ -6,4 +6,5 @@ __all__ = [
     "AbstractPrompt",
     "CorrectErrorPrompt",
     "GeneratePythonCodePrompt",
+    "FileBasedPrompt",
 ]

--- a/pandasai/prompts/base.py
+++ b/pandasai/prompts/base.py
@@ -6,7 +6,10 @@ from abc import ABC, abstractmethod
 
 
 class AbstractPrompt(ABC):
-    """Base class to implement a new Prompt"""
+    """Base class to implement a new Prompt.
+
+    Inheritors have to override `template` property.
+    """
 
     _args = {}
 
@@ -47,7 +50,7 @@ This is the metadata of the dataframe dfs[{index-1}]:
 
     @property
     @abstractmethod
-    def template(self):
+    def template(self) -> str:
         ...
 
     def set_var(self, var, value):
@@ -63,6 +66,11 @@ This is the metadata of the dataframe dfs[{index-1}]:
 
 
 class FileBasedPrompt(AbstractPrompt):
+    """Base class for prompts supposed to read template content from a file.
+
+    `_path_to_template` attribute has to be specified.
+    """
+
     _path_to_template: str
 
     def __init__(self, **kwargs):
@@ -72,7 +80,7 @@ class FileBasedPrompt(AbstractPrompt):
         super().__init__(**kwargs)
 
     @property
-    def template(self):
+    def template(self) -> str:
         if not os.path.exists(self._path_to_template):
             raise FileNotFoundError(
                 f"Unable to find a file with template at '{self._path_to_template}' "

--- a/pandasai/prompts/base.py
+++ b/pandasai/prompts/base.py
@@ -1,14 +1,13 @@
 """ Base class to implement a new Prompt
 In order to better handle the instructions, this prompt module is written.
 """
+import os
+from abc import ABC, abstractmethod
 
-from pandasai.exceptions import MethodNotImplementedError
 
-
-class Prompt:
+class AbstractPrompt(ABC):
     """Base class to implement a new Prompt"""
 
-    text = None
     _args = {}
 
     def __init__(self, **kwargs):
@@ -46,16 +45,38 @@ This is the metadata of the dataframe dfs[{index-1}]:
 
         return "\n\n".join(dataframes)
 
+    @property
+    @abstractmethod
+    def template(self):
+        ...
+
     def set_var(self, var, value):
         if var == "dfs":
             self._args["dataframes"] = self._generate_dataframes(value)
         self._args[var] = value
 
     def to_string(self):
-        if self.text is None:
-            raise MethodNotImplementedError
-
-        return self.text.format(**self._args)
+        return self.template.format(**self._args)
 
     def __str__(self):
         return self.to_string()
+
+
+class FileBasedPrompt(AbstractPrompt):
+    _path_to_template: str
+
+    def __init__(self, **kwargs):
+        if (template_path := kwargs.pop("path_to_template", None)) is not None:
+            self._path_to_template = template_path
+
+        super().__init__(**kwargs)
+
+    @property
+    def template(self):
+        if not os.path.exists(self._path_to_template):
+            raise FileNotFoundError(
+                f"Unable to find a file with template at '{self._path_to_template}' "
+                f"for '{self.__class__.__name__}' prompt."
+            )
+        with open(self._path_to_template) as fp:
+            return fp.read()

--- a/pandasai/prompts/base.py
+++ b/pandasai/prompts/base.py
@@ -1,8 +1,9 @@
 """ Base class to implement a new Prompt
 In order to better handle the instructions, this prompt module is written.
 """
-import os
 from abc import ABC, abstractmethod
+
+from ..exceptions import TemplateFileNotFoundError
 
 
 class AbstractPrompt(ABC):
@@ -81,10 +82,14 @@ class FileBasedPrompt(AbstractPrompt):
 
     @property
     def template(self) -> str:
-        if not os.path.exists(self._path_to_template):
-            raise FileNotFoundError(
-                f"Unable to find a file with template at '{self._path_to_template}' "
-                f"for '{self.__class__.__name__}' prompt."
+        try:
+            with open(self._path_to_template) as fp:
+                return fp.read()
+        except FileNotFoundError:
+            raise TemplateFileNotFoundError(
+                self._path_to_template, self.__class__.__name__
             )
-        with open(self._path_to_template) as fp:
-            return fp.read()
+        except IOError as exc:
+            raise RuntimeError(
+                f"Failed to read template file '{self._path_to_template}': {exc}"
+            )

--- a/pandasai/prompts/correct_error_prompt.py
+++ b/pandasai/prompts/correct_error_prompt.py
@@ -16,25 +16,10 @@ It fails with the following error:
 Correct the python code and return a new python code (do not import anything) that fixes the above mentioned error. Do not generate the same code again.
 """  # noqa: E501
 
-from .base import Prompt
+from .base import FileBasedPrompt
 
 
-class CorrectErrorPrompt(Prompt):
+class CorrectErrorAbstractPrompt(FileBasedPrompt):
     """Prompt to Correct Python code on Error"""
 
-    text: str = """
-You are provided with the following {engine} DataFrames with the following metadata:
-
-{dataframes}
-
-The user asked the following question:
-{conversation}
-
-You generated this python code:
-{code}
-
-It fails with the following error:
-{error_returned}
-
-Correct the python code and return a new python code (do not import anything) that fixes the above mentioned error. Do not generate the same code again.
-"""  # noqa: E501
+    _path_to_template = "assets/prompt-templates/correct_error_prompt.tmpl"

--- a/pandasai/prompts/correct_error_prompt.py
+++ b/pandasai/prompts/correct_error_prompt.py
@@ -19,7 +19,7 @@ Correct the python code and return a new python code (do not import anything) th
 from .base import FileBasedPrompt
 
 
-class CorrectErrorAbstractPrompt(FileBasedPrompt):
+class CorrectErrorPrompt(FileBasedPrompt):
     """Prompt to Correct Python code on Error"""
 
     _path_to_template = "assets/prompt-templates/correct_error_prompt.tmpl"

--- a/pandasai/prompts/generate_python_code.py
+++ b/pandasai/prompts/generate_python_code.py
@@ -36,7 +36,7 @@ Updated code:
 from .base import FileBasedPrompt
 
 
-class GeneratePythonCodeAbstractPrompt(FileBasedPrompt):
+class GeneratePythonCodePrompt(FileBasedPrompt):
     """Prompt to generate Python code"""
 
     _path_to_template = "assets/prompt-templates/generate_python_code.tmpl"

--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -33,8 +33,8 @@ from ..helpers.memory import Memory
 from ..schemas.df_config import Config
 from ..config import load_config
 from ..prompts.base import AbstractPrompt
-from ..prompts.correct_error_prompt import CorrectErrorAbstractPrompt
-from ..prompts.generate_python_code import GeneratePythonCodeAbstractPrompt
+from ..prompts.correct_error_prompt import CorrectErrorPrompt
+from ..prompts.generate_python_code import GeneratePythonCodePrompt
 from typing import Union, List, Any, Type, Optional
 from ..helpers.code_manager import CodeManager
 from ..middlewares.base import Middleware
@@ -287,7 +287,7 @@ class SmartDatalake:
                 }
                 generate_python_code_instruction = self._get_prompt(
                     "generate_python_code",
-                    default_prompt=GeneratePythonCodeAbstractPrompt,
+                    default_prompt=GeneratePythonCodePrompt,
                     default_values=default_values,
                 )
 
@@ -436,7 +436,7 @@ class SmartDatalake:
         }
         error_correcting_instruction = self._get_prompt(
             "correct_error",
-            default_prompt=CorrectErrorAbstractPrompt,
+            default_prompt=CorrectErrorPrompt,
             default_values=default_values,
         )
 

--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -32,9 +32,9 @@ from ..helpers.cache import Cache
 from ..helpers.memory import Memory
 from ..schemas.df_config import Config
 from ..config import load_config
-from ..prompts.base import Prompt
-from ..prompts.correct_error_prompt import CorrectErrorPrompt
-from ..prompts.generate_python_code import GeneratePythonCodePrompt
+from ..prompts.base import AbstractPrompt
+from ..prompts.correct_error_prompt import CorrectErrorAbstractPrompt
+from ..prompts.generate_python_code import GeneratePythonCodeAbstractPrompt
 from typing import Union, List, Any, Type, Optional
 from ..helpers.code_manager import CodeManager
 from ..middlewares.base import Middleware
@@ -204,20 +204,20 @@ class SmartDatalake:
     def _get_prompt(
         self,
         key: str,
-        default_prompt: Type[Prompt],
+        default_prompt: Type[AbstractPrompt],
         default_values: Optional[dict] = None,
-    ) -> Prompt:
+    ) -> AbstractPrompt:
         """
         Return a prompt by key.
 
         Args:
             key (str): The key of the prompt
-            default_prompt (Type[Prompt]): The default prompt to use
+            default_prompt (Type[AbstractPrompt]): The default prompt to use
             default_values (Optional[dict], optional): The default values to use for the
             prompt. Defaults to None.
 
         Returns:
-            Prompt: The prompt
+            AbstractPrompt: The prompt
         """
         if default_values is None:
             default_values = {}
@@ -287,7 +287,7 @@ class SmartDatalake:
                 }
                 generate_python_code_instruction = self._get_prompt(
                     "generate_python_code",
-                    default_prompt=GeneratePythonCodePrompt,
+                    default_prompt=GeneratePythonCodeAbstractPrompt,
                     default_values=default_values,
                 )
 
@@ -436,7 +436,7 @@ class SmartDatalake:
         }
         error_correcting_instruction = self._get_prompt(
             "correct_error",
-            default_prompt=CorrectErrorPrompt,
+            default_prompt=CorrectErrorAbstractPrompt,
             default_values=default_values,
         )
 

--- a/tests/connectors/test_base.py
+++ b/tests/connectors/test_base.py
@@ -14,7 +14,6 @@ class MockConfig:
 
 # Mock subclass of BaseConnector for testing
 class MockConnector(BaseConnector):
-
     def _load_connector_config(self, config: BaseConnectorConfig):
         pass
 

--- a/tests/llms/test_base_hf.py
+++ b/tests/llms/test_base_hf.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 
 from pandasai.llm.base import HuggingFaceLLM
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 
 
 class TestBaseHfLLM:
@@ -16,10 +16,10 @@ class TestBaseHfLLM:
 
     @pytest.fixture
     def prompt(self):
-        class MockPrompt(Prompt):
-            text: str = "instruction"
+        class MockAbstractPrompt(AbstractPrompt):
+            template: str = "instruction"
 
-        return MockPrompt()
+        return MockAbstractPrompt()
 
     def test_type(self):
         assert HuggingFaceLLM(api_token="test_token").type == "huggingface-llm"
@@ -62,10 +62,10 @@ class TestBaseHfLLM:
     def test_call_removes_original_prompt(self, mocker):
         huggingface = HuggingFaceLLM(api_token="test_token")
 
-        class MockPrompt(Prompt):
-            text: str = "instruction "
+        class MockAbstractPrompt(AbstractPrompt):
+            template: str = "instruction "
 
-        instruction = MockPrompt()
+        instruction = MockAbstractPrompt()
         suffix = "suffix "
 
         mocker.patch.object(

--- a/tests/llms/test_google_palm.py
+++ b/tests/llms/test_google_palm.py
@@ -6,7 +6,7 @@ from google import generativeai
 
 from pandasai.exceptions import APIKeyNotFoundError
 from pandasai.llm import GooglePalm
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 
 
 class MockedCompletion:
@@ -19,10 +19,10 @@ class TestGooglePalm:
 
     @pytest.fixture
     def prompt(self):
-        class MockPrompt(Prompt):
-            text: str = "Hello"
+        class MockAbstractPrompt(AbstractPrompt):
+            template: str = "Hello"
 
-        return MockPrompt()
+        return MockAbstractPrompt()
 
     def test_type_without_token(self):
         with pytest.raises(APIKeyNotFoundError):

--- a/tests/llms/test_huggingface_text_gen.py
+++ b/tests/llms/test_huggingface_text_gen.py
@@ -1,10 +1,10 @@
 """Unit tests for the LLaMa2TextGen LLM class"""
-from pandasai import Prompt
+from pandasai import AbstractPrompt
 from pandasai.llm import HuggingFaceTextGen
 
 
-class MockPrompt(Prompt):
-    text: str = "instruction."
+class MockAbstractPrompt(AbstractPrompt):
+    template: str = "instruction."
 
 
 class MockResponse:
@@ -19,9 +19,8 @@ class TestHuggingFaceTextGen:
 
     def test_type_with_token(self):
         assert (
-                HuggingFaceTextGen(
-                inference_server_url="http://127.0.0.1:8080"
-            ).type == "huggingface-text-generation"
+            HuggingFaceTextGen(inference_server_url="http://127.0.0.1:8080").type
+            == "huggingface-text-generation"
         )
 
     def test_params_setting(self):
@@ -30,7 +29,7 @@ class TestHuggingFaceTextGen:
             max_new_tokens=1024,
             top_p=0.8,
             typical_p=0.8,
-            temperature=1E-3,
+            temperature=1e-3,
             stop_sequences=["\n"],
             seed=0,
             do_sample=False,
@@ -53,11 +52,9 @@ class TestHuggingFaceTextGen:
         expected_text = "This is the generated text."
         tgi_mock.return_value = MockResponse(expected_text)
 
-        llm = HuggingFaceTextGen(
-            inference_server_url="http://127.0.0.1:8080"
-        )
+        llm = HuggingFaceTextGen(inference_server_url="http://127.0.0.1:8080")
 
-        instruction = MockPrompt()
+        instruction = MockAbstractPrompt()
         result = llm.call(instruction)
 
         tgi_mock.assert_called_once_with(

--- a/tests/llms/test_langchain_llm.py
+++ b/tests/llms/test_langchain_llm.py
@@ -4,7 +4,7 @@ from langchain.llms import OpenAI
 import pytest
 
 from pandasai.llm import LangchainLLM
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 from unittest.mock import Mock
 
 
@@ -25,10 +25,10 @@ class TestLangchainLLM:
 
     @pytest.fixture
     def prompt(self):
-        class MockPrompt(Prompt):
-            text: str = "Hello"
+        class MockAbstractPrompt(AbstractPrompt):
+            template: str = "Hello"
 
-        return MockPrompt()
+        return MockAbstractPrompt()
 
     def test_langchain_llm_type(self, langchain_llm):
         langchain_wrapper = LangchainLLM(langchain_llm)

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -4,7 +4,7 @@ import pytest
 
 from pandasai.exceptions import APIKeyNotFoundError, UnsupportedOpenAIModelError
 from pandasai.llm import OpenAI
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 from openai.openai_object import OpenAIObject
 
 
@@ -13,10 +13,10 @@ class TestOpenAILLM:
 
     @pytest.fixture
     def prompt(self):
-        class MockPrompt(Prompt):
-            text: str = "instruction"
+        class MockAbstractPrompt(AbstractPrompt):
+            template: str = "instruction"
 
-        return MockPrompt()
+        return MockAbstractPrompt()
 
     def test_type_without_token(self):
         with pytest.raises(APIKeyNotFoundError):

--- a/tests/prompts/test_base_prompt.py
+++ b/tests/prompts/test_base_prompt.py
@@ -2,56 +2,10 @@
 
 import pytest
 
-from pandasai.exceptions import MethodNotImplementedError
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 
 
 class TestBasePrompt:
-    """Unit tests for the base prompt class"""
-
-    def test_text(self):
-        """Test that the text attribute is required"""
-        with pytest.raises(MethodNotImplementedError):
-            print(Prompt())
-
-    def test_str(self):
-        """Test that the __str__ method is implemented"""
-
-        class TestPrompt(Prompt):
-            """Test prompt"""
-
-            text = "Test prompt"
-
-        assert str(TestPrompt()) == "Test prompt"
-
-    def test_str_not_implemented(self):
-        """Test that the __str__ method is implemented"""
-
-        class TestPrompt(Prompt):
-            """Test prompt"""
-
-            pass
-
-        with pytest.raises(MethodNotImplementedError):
-            str(TestPrompt())
-
-    def test_str_with_args(self):
-        """Test that the __str__ method is implemented"""
-
-        class TestPrompt(Prompt):
-            """Test prompt"""
-
-            text = "Test prompt {arg1} {arg2}"
-
-        assert str(TestPrompt(arg1="arg1", arg2="arg2")) == "Test prompt arg1 arg2"
-
-    def test_str_with_args_not_implemented(self):
-        """Test that the __str__ method is implemented"""
-
-        class TestPrompt(Prompt):
-            """Test prompt"""
-
-            text = "Test prompt {arg1} {arg2}"
-
-        with pytest.raises(KeyError):
-            str(TestPrompt())
+    def test_instantiate_without_template(self):
+        with pytest.raises(TypeError):
+            AbstractPrompt()

--- a/tests/prompts/test_correct_error_prompt.py
+++ b/tests/prompts/test_correct_error_prompt.py
@@ -1,8 +1,9 @@
 """Unit tests for the correct error prompt class"""
+import sys
 
 import pandas as pd
 from pandasai import SmartDataframe
-from pandasai.prompts import CorrectErrorPrompt
+from pandasai.prompts import CorrectErrorAbstractPrompt
 from pandasai.llm.fake import FakeLLM
 
 
@@ -19,14 +20,17 @@ class TestCorrectErrorPrompt:
                 config={"llm": llm},
             )
         ]
-        prompt = CorrectErrorPrompt(
+        prompt = CorrectErrorAbstractPrompt(
             engine="pandas", code="df.head()", error_returned="Error message"
         )
         prompt.set_var("dfs", dfs)
         prompt.set_var("conversation", "What is the correct code?")
+        prompt_content = prompt.to_string()
+        if sys.platform.startswith("win"):
+            prompt_content = prompt_content.replace("\r\n", "\n")
 
         assert (
-            prompt.to_string()
+            prompt_content
             == """
 You are provided with the following pandas DataFrames with the following metadata:
 

--- a/tests/prompts/test_correct_error_prompt.py
+++ b/tests/prompts/test_correct_error_prompt.py
@@ -3,7 +3,7 @@ import sys
 
 import pandas as pd
 from pandasai import SmartDataframe
-from pandasai.prompts import CorrectErrorAbstractPrompt
+from pandasai.prompts import CorrectErrorPrompt
 from pandasai.llm.fake import FakeLLM
 
 
@@ -20,7 +20,7 @@ class TestCorrectErrorPrompt:
                 config={"llm": llm},
             )
         ]
-        prompt = CorrectErrorAbstractPrompt(
+        prompt = CorrectErrorPrompt(
             engine="pandas", code="df.head()", error_returned="Error message"
         )
         prompt.set_var("dfs", dfs)

--- a/tests/prompts/test_generate_python_code_prompt.py
+++ b/tests/prompts/test_generate_python_code_prompt.py
@@ -1,9 +1,9 @@
 """Unit tests for the generate python code prompt class"""
-
+import sys
 
 import pandas as pd
 from pandasai import SmartDataframe
-from pandasai.prompts import GeneratePythonCodePrompt
+from pandasai.prompts import GeneratePythonCodeAbstractPrompt
 from pandasai.llm.fake import FakeLLM
 
 
@@ -20,12 +20,17 @@ class TestGeneratePythonCodePrompt:
                 config={"llm": llm},
             )
         ]
-        prompt = GeneratePythonCodePrompt()
+        prompt = GeneratePythonCodeAbstractPrompt()
         prompt.set_var("dfs", dfs)
         prompt.set_var("conversation", "Question")
         prompt.set_var("save_charts_path", "exports/charts")
+
+        prompt_content = prompt.to_string()
+        if sys.platform.startswith("win"):
+            prompt_content = prompt_content.replace("\r\n", "\n")
+
         assert (
-            prompt.to_string()
+            prompt_content
             == """
 You are provided with the following pandas DataFrames:
 
@@ -75,13 +80,17 @@ Updated code:
             )
         ]
 
-        prompt = GeneratePythonCodePrompt()
+        prompt = GeneratePythonCodeAbstractPrompt()
         prompt.set_var("dfs", dfs)
         prompt.set_var("conversation", "Question")
         prompt.set_var("save_charts_path", "custom_path")
 
+        prompt_content = prompt.to_string()
+        if sys.platform.startswith("win"):
+            prompt_content = prompt_content.replace("\r\n", "\n")
+
         assert (
-            prompt.to_string()
+            prompt_content
             == """
 You are provided with the following pandas DataFrames:
 

--- a/tests/prompts/test_generate_python_code_prompt.py
+++ b/tests/prompts/test_generate_python_code_prompt.py
@@ -3,7 +3,7 @@ import sys
 
 import pandas as pd
 from pandasai import SmartDataframe
-from pandasai.prompts import GeneratePythonCodeAbstractPrompt
+from pandasai.prompts import GeneratePythonCodePrompt
 from pandasai.llm.fake import FakeLLM
 
 
@@ -20,7 +20,7 @@ class TestGeneratePythonCodePrompt:
                 config={"llm": llm},
             )
         ]
-        prompt = GeneratePythonCodeAbstractPrompt()
+        prompt = GeneratePythonCodePrompt()
         prompt.set_var("dfs", dfs)
         prompt.set_var("conversation", "Question")
         prompt.set_var("save_charts_path", "exports/charts")
@@ -80,7 +80,7 @@ Updated code:
             )
         ]
 
-        prompt = GeneratePythonCodeAbstractPrompt()
+        prompt = GeneratePythonCodePrompt()
         prompt.set_var("dfs", dfs)
         prompt.set_var("conversation", "Question")
         prompt.set_var("save_charts_path", "custom_path")

--- a/tests/test_smartdataframe.py
+++ b/tests/test_smartdataframe.py
@@ -17,7 +17,7 @@ from pandasai.exceptions import LLMNotFoundError
 from pandasai.llm.fake import FakeLLM
 from pandasai.middlewares import Middleware
 from pandasai.callbacks import StdoutCallback
-from pandasai.prompts import AbstractPrompt
+from pandasai.prompts import AbstractPrompt, GeneratePythonCodePrompt
 from pandasai.helpers.cache import Cache
 
 import logging
@@ -377,13 +377,13 @@ result = analyze_data(dfs)
         smart_dataframe.chat.assert_called_once()
 
     def test_replace_generate_code_prompt(self, llm):
-        class CustomAbstractPrompt(AbstractPrompt):
+        class CustomPrompt(AbstractPrompt):
             template: str = """{test} || {dfs[0].shape[1]} || {conversation}"""
 
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)
 
-        replacement_prompt = CustomAbstractPrompt(test="test value")
+        replacement_prompt = CustomPrompt(test="test value")
         df = SmartDataframe(
             pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
             config={
@@ -512,7 +512,9 @@ result = analyze_data(dfs)
         smart_dataframe.use_error_correction_framework = False
         assert smart_dataframe.use_error_correction_framework is False
 
-        smart_dataframe.custom_prompts = {"generate_python_code": AbstractPrompt()}
+        smart_dataframe.custom_prompts = {
+            "generate_python_code": GeneratePythonCodePrompt()
+        }
         assert smart_dataframe.custom_prompts != {}
 
         smart_dataframe.save_charts = True

--- a/tests/test_smartdataframe.py
+++ b/tests/test_smartdataframe.py
@@ -17,7 +17,7 @@ from pandasai.exceptions import LLMNotFoundError
 from pandasai.llm.fake import FakeLLM
 from pandasai.middlewares import Middleware
 from pandasai.callbacks import StdoutCallback
-from pandasai.prompts import Prompt
+from pandasai.prompts import AbstractPrompt
 from pandasai.helpers.cache import Cache
 
 import logging
@@ -377,13 +377,13 @@ result = analyze_data(dfs)
         smart_dataframe.chat.assert_called_once()
 
     def test_replace_generate_code_prompt(self, llm):
-        class CustomPrompt(Prompt):
-            text: str = """{test} || {dfs[0].shape[1]} || {conversation}"""
+        class CustomAbstractPrompt(AbstractPrompt):
+            template: str = """{test} || {dfs[0].shape[1]} || {conversation}"""
 
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)
 
-        replacement_prompt = CustomPrompt(test="test value")
+        replacement_prompt = CustomAbstractPrompt(test="test value")
         df = SmartDataframe(
             pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
             config={
@@ -399,8 +399,10 @@ result = analyze_data(dfs)
         assert llm.last_prompt == expected_last_prompt
 
     def test_replace_correct_error_prompt(self, llm):
-        class ReplacementPrompt(Prompt):
-            text = "Custom prompt"
+        class ReplacementPrompt(AbstractPrompt):
+            @property
+            def template(self):
+                return "Custom prompt"
 
         replacement_prompt = ReplacementPrompt()
         df = SmartDataframe(
@@ -510,7 +512,7 @@ result = analyze_data(dfs)
         smart_dataframe.use_error_correction_framework = False
         assert smart_dataframe.use_error_correction_framework is False
 
-        smart_dataframe.custom_prompts = {"generate_python_code": Prompt()}
+        smart_dataframe.custom_prompts = {"generate_python_code": AbstractPrompt()}
         assert smart_dataframe.custom_prompts != {}
 
         smart_dataframe.save_charts = True

--- a/tests/test_smartdatalake.py
+++ b/tests/test_smartdatalake.py
@@ -1,5 +1,6 @@
 """Unit tests for the SmartDatalake class"""
 import os
+import sys
 
 from typing import Optional
 from unittest.mock import Mock, patch
@@ -146,8 +147,12 @@ class TestSmartDatalake:
             e=Exception("Test error"),
         )
 
+        last_prompt = smart_datalake.last_prompt
+        if sys.platform.startswith("win"):
+            last_prompt = last_prompt.replace("\r\n", "\n")
+
         assert (
-            smart_datalake.last_prompt
+            last_prompt
             == """
 You are provided with the following pandas DataFrames with the following metadata:
 


### PR DESCRIPTION
This commit contains refactoring updates related to #593.
Brief summary:
* rename `Prompt` -> `AbstractPrompt`
* inheritors of `AbstractPrompt` now should implement property `template` (before `text` attribute had the same sense, but tempalte is more accurate IMHO for this case)
* add `FileBasedPrompt` (extends `AbstractPrompt`)
* add directory assets/prompt-templates/
* move content of `CorrectErrorPrompt` and `GeneratePythonCodePrompt` to assets/prompt-templates/correct_error_prompt.tmpl and assets/prompt-templates/generate_python_code.tmpl respectively
* `CorrectErrorPrompt` and `GeneratePythonCodePrompt` now extend `FileBasedPrompt`
* Update docs accordingly
* Update tests accordingly

___

* (refactor): define base prompt class as an abstract
* (refactor): attribute `text` rename to `template` (since it's essentially is a template)
* (feat): add FileBasedPrompt

- [x] closes #593
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `AbstractPrompt` and `FileBasedPrompt` classes to support a more flexible prompt system, including file-based prompts.
- Refactor: Replaced all instances of the `Prompt` class with `AbstractPrompt` across the codebase for consistency.
- Bug Fix: Addressed an issue with inconsistent line endings in test cases across different platforms.
- New Feature: Added new exception classes `TemplateFileNotFoundError` and `LibraryImportError` for better error handling and reporting.
- Test: Updated unit tests to reflect changes in the prompt system and added new tests for the `AbstractPrompt` class.
- Chore: Updated documentation to reflect changes in the prompt system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->