### PR TITLE
fix(llms): restore completion API for gpt-3.5-turbo-instruct

### DIFF
--- a/pandasai/llm/openai.py
+++ b/pandasai/llm/openai.py
@@ -29,7 +29,8 @@ class OpenAI(BaseOpenAI):
     The list of supported Chat models includes ["gpt-4", "gpt-4-0613", "gpt-4-32k",
      "gpt-4-32k-0613", "gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0613",
      "gpt-3.5-turbo-16k-0613", "gpt-3.5-turbo-instruct"].
-
+    The list of supported Completion models includes "gpt-3.5-turbo-instruct" and
+     "text-davinci-003" (soon to be deprecated).
     """
 
     _supported_chat_models = [
@@ -41,8 +42,8 @@ class OpenAI(BaseOpenAI):
         "gpt-3.5-turbo-16k",
         "gpt-3.5-turbo-0613",
         "gpt-3.5-turbo-16k-0613",
-        "gpt-3.5-turbo-instruct",
     ]
+    _supported_completion_models = ["text-davinci-003", "gpt-3.5-turbo-instruct"]
 
     model: str = "gpt-3.5-turbo"
 
@@ -101,7 +102,9 @@ class OpenAI(BaseOpenAI):
         """
         self.last_prompt = instruction.to_string() + suffix
 
-        if self.model in self._supported_chat_models:
+        if self.model in self._supported_completion_models:
+            response = self.completion(self.last_prompt)
+        elif self.model in self._supported_chat_models:
             response = self.chat_completion(self.last_prompt)
         else:
             raise UnsupportedOpenAIModelError("Unsupported model")

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -111,6 +111,13 @@ class TestOpenAILLM:
             llm = OpenAI(api_token="test", model="not a model")
             llm.call(instruction=prompt)
 
+    def test_call_supported_completion_model(self, mocker, prompt):
+        openai = OpenAI(api_token="test", model="gpt-3.5-turbo-instruct")
+        mocker.patch.object(openai, "completion", return_value="response")
+
+        result = openai.call(instruction=prompt)
+        assert result == "response"
+
     def test_call_supported_chat_model(self, mocker, prompt):
         openai = OpenAI(api_token="test", model="gpt-4")
         mocker.patch.object(openai, "chat_completion", return_value="response")


### PR DESCRIPTION
Hi @gventuri,
this PR aims at restoring the `Completion` API as `gpt-3.5-turbo-instruct` is a completion model[^1]. Also, I restored `text-davinci-003` since it will be discontinued in 10 months but somebody might still be interested in using it for the time being. 

- [X] Tests added and passed if fixing a bug or adding a new feature
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

[^1]: despite OpenAI marking the `Completion` API as "Legacy", they have introduced  `gpt-3.5-turbo-instruct` as a replacement for all the other completions models
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for the "gpt-3.5-turbo-instruct" model to the `OpenAI` class in the `pandasai/llm/openai.py` file.
- New Feature: Introduced a new list `_supported_completion_models` with two models: "text-davinci-003" and "gpt-3.5-turbo-instruct". This allows the `call` method to select the appropriate completion method based on the model used.
- Test: Added a new test case `test_call_supported_completion_model` in the `tests/llms/test_openai.py` file to ensure that the updated logic in the `call` method works as expected when using supported completion models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->