### PR TITLE
fix(smartdataframe) : Changed path parameter for exporting

### DIFF
--- a/pandasai/smart_dataframe/abstract_df.py
+++ b/pandasai/smart_dataframe/abstract_df.py
@@ -279,7 +279,7 @@ class DataframeAbstract(ABC):
         """
         A proxy-call to the dataframe's `.to_csv()`.
         """
-        return self.dataframe.to_csv(path=path)
+        return self.dataframe.to_csv(path_or_buf=path)
 
     def to_json(self, path):
         """


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

As per official documentation of [pandas](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html) , The parameter for exporting dataframe to csv is `path_or_buf` not `path`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Enhancement: Modified the `to_csv()` method in the `abstract_df.py` file. The method now accepts both a file path and a buffer as the destination for writing CSV data, increasing flexibility and usability. This change does not affect existing functionality when providing a file path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->