### PR TITLE
fix: dependency move streamlit import inline

### DIFF
--- a/pandasai/responses/streamlit_response.py
+++ b/pandasai/responses/streamlit_response.py
@@ -1,13 +1,5 @@
 from pandasai.responses.response_parser import ResponseParser
 
-try:
-    import streamlit as st
-except ImportError:
-    raise ImportError(
-        "The 'streamlit' module is required but not installed. "
-        "Please install it using pip: pip install streamlit"
-    )
-
 
 class StreamlitResponse(ResponseParser):
     def __init__(self, context):
@@ -29,6 +21,14 @@ class StreamlitResponse(ResponseParser):
             raise FileNotFoundError(f"The file {result['value']} does not exist.")
         except OSError:
             raise ValueError(f"The file {result['value']} is not a valid image file.")
+
+        try:
+            import streamlit as st
+        except ImportError:
+            raise ImportError(
+                "The 'streamlit' module is required to use StreamLit Response. "
+                "Please install it using pip: pip install streamlit"
+            )
 
         # Display the image
         plt.imshow(image)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Moved the import of the `streamlit` module inside the `format_plot` function in `streamlit_response.py` to improve modularity and encapsulation.
- Bug Fix: Added error handling to raise an `ImportError` if the `streamlit` module is not installed, providing better feedback to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->