### PR TITLE
feat: Raise an exception when get error HTTP code (#646)

### DIFF
--- a/pandasai/exceptions.py
+++ b/pandasai/exceptions.py
@@ -68,6 +68,24 @@ class MissingModelError(Exception):
     """
 
 
+class LLMResponseHTTPError(Exception):
+    """
+    Raised when a remote LLM service responses with error HTTP code.
+
+    Args:
+        Exception (Exception): LLMResponseHTTPError
+    """
+
+    def __init__(self, status_code, error_msg=None):
+        self.status_code = status_code
+        self.error_msg = error_msg
+
+        super().__init__(
+            f"The remote server has responded with an error HTTP "
+            f"code: {status_code}; {error_msg or ''}"
+        )
+
+
 class BadImportError(Exception):
     """
     Raised when a library not in the whitelist is imported.

--- a/tests/llms/test_base_hf.py
+++ b/tests/llms/test_base_hf.py
@@ -3,6 +3,7 @@
 import pytest
 import requests
 
+from pandasai.exceptions import LLMResponseHTTPError
 from pandasai.llm.base import HuggingFaceLLM
 from pandasai.prompts import AbstractPrompt
 
@@ -13,6 +14,10 @@ class TestBaseHfLLM:
     @pytest.fixture
     def api_response(self):
         return [{"generated_text": "Some text"}]
+
+    @pytest.fixture
+    def api_response_401(self):
+        return {"error": "Authorization header is correct, but the token seems invalid"}
 
     @pytest.fixture
     def prompt(self):
@@ -32,6 +37,7 @@ class TestBaseHfLLM:
 
     def test_query(self, mocker, api_response):
         response_mock = mocker.Mock()
+        response_mock.status_code = 200
         response_mock.json.return_value = api_response
         mocker.patch("requests.post", return_value=response_mock)
 
@@ -50,6 +56,27 @@ class TestBaseHfLLM:
 
         # Check that the result is correct
         assert result == api_response[0]["generated_text"]
+
+    def test_query_http_error_401(self, mocker, api_response_401):
+        response_mock = mocker.Mock()
+        response_mock.status_code = 401
+        response_mock.json.return_value = api_response_401
+        mocker.patch("requests.post", return_value=response_mock)
+
+        llm = HuggingFaceLLM(api_token="test_token")
+        payload = {"inputs": "Some input text"}
+
+        with pytest.raises(LLMResponseHTTPError) as exc:
+            llm.query(payload)
+
+        assert api_response_401.get("error") in str(exc.value)
+
+        requests.post.assert_called_once_with(
+            llm._api_url,
+            headers={"Authorization": "Bearer test_token"},
+            json=payload,
+            timeout=60,
+        )
 
     def test_call(self, mocker, prompt):
         huggingface = HuggingFaceLLM(api_token="test_token")


### PR DESCRIPTION
This PR aims to resolve the problem described in #646. 

Add:
- Raising `LLMResponseHTTPError` when an API for `HuggingFaceLLM` responses with 400+ code (e. g. invalid token, a remote server in under maintenance, etc.)
- According tests to check if the exception is raised

___

P. S. added the one only for `HuggingFaceLLM` class, because for others we have some different API calls (using `openai` SDK package for OpenAI for example)

___

* (feat): add `LLMResponseHTTPError` in exceptions.py
* (feat): raise `LLMResponseHTTPError` when HuggingFace LLM get HTTP code greater or equal to 400 (i. e. some error occurred)

- [x] Closes #646
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a new error handling mechanism for our software. Now, when our system interacts with external services and encounters an issue, it will provide more detailed feedback. This will help us diagnose and resolve issues more efficiently.
- Test: Added new tests to ensure this error handling works as expected. This will help maintain the reliability of our system and ensure a smooth user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->