### PR TITLE
Fix `enforce_privacy=True`

### DIFF
--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -433,7 +433,10 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
         sampler = DataSampler(head)
         sampled_head = sampler.sample(rows_to_display)
 
-        return self._truncate_head_columns(sampled_head)
+        if self.lake.config.enforce_privacy:
+            return sampled_head
+        else:
+            return self._truncate_head_columns(sampled_head)
 
     def _load_from_config(self, name: str):
         """


### PR DESCRIPTION
Resolves  #662

- [X] closes #662 (Replace xxxx with the GitHub issue number)
- [X] Tests added and passed if fixing a bug or adding a new feature
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Enhanced privacy settings in our data handling. Depending on your privacy preferences, you can now choose to view complete or truncated data samples. This feature is controlled by the `enforce_privacy` setting. When enabled, you'll see the full data sample; when disabled, you'll see a truncated version. This change gives you more control over your data privacy and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->