### PR TITLE
docs: add edit_uri in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: PandasAI
 site_url: https://pandasai.readthedocs.io/en/latest/
 repo_url: https://github.com/gventuri/pandas-ai
+edit_uri: https://github.com/gventuri/pandas-ai/blob/main/docs/
 site_description: PandasAI is a Python library that integrates generative artificial intelligence capabilities into pandas, making dataframes conversational
 site_author: Gabriele Venturi
 


### PR DESCRIPTION
Add edit uri to solve the issue Link at main doc page is pointing to non-existent page #670

- [ ] closes #670
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).
