### PR TITLE
feat: add support for sqlite connectors

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -89,6 +89,28 @@ df = SmartDataframe(mysql_connector)
 df.chat('What is the total amount of loans in the last year?')
 ```
 
+### Sqlite connector
+
+Similarly to the PostgreSQL and MySQL connectors, the Sqlite connector allows you to connect to a local Sqlite database file. It is designed to be easy to use, even if you are not familiar with Sqlite or with PandasAI.
+
+To use the Sqlite connector, you only need to import it into your Python code and pass it to a `SmartDataframe` or `SmartDatalake` object:
+
+```python
+from pandasai.connectors import SqliteConnector
+
+connector = SqliteConnector(config={
+    "database" : "PATH_TO_DB",
+    "table" : "actor",
+    "where" :[
+        ["first_name","=","PENELOPE"]
+    ]
+})
+
+df = SmartDataframe(connector)
+df.chat('How many records are there ?')
+```
+
+
 ### Generic SQL connector
 
 The generic SQL connector allows you to connect to any SQL database that is supported by SQLAlchemy.

--- a/examples/from_sql.py
+++ b/examples/from_sql.py
@@ -50,7 +50,10 @@ invoice_connector = SqliteConnector(
     }
 )
 llm = OpenAI()
-df = SmartDatalake([loan_connector, payment_connector,invoice_connector], config={"llm": llm})
+df = SmartDatalake(
+        [loan_connector, payment_connector,invoice_connector], 
+        config={"llm": llm}
+    )
 response = df.chat("How many people from the United states?")
 print(response)
 # Output: 247 loans have been paid off by men.

--- a/examples/from_sql.py
+++ b/examples/from_sql.py
@@ -2,7 +2,7 @@
 
 from pandasai import SmartDatalake
 from pandasai.llm import OpenAI
-from pandasai.connectors import MySQLConnector, PostgreSQLConnector,SqliteConnector
+from pandasai.connectors import MySQLConnector, PostgreSQLConnector, SqliteConnector
 
 # With a MySQL database
 loan_connector = MySQLConnector(
@@ -38,22 +38,19 @@ payment_connector = PostgreSQLConnector(
     }
 )
 
-# With a Sqlite databse 
+# With a Sqlite databse
 
 invoice_connector = SqliteConnector(
     config={
-        "database" : "local_path_to_db",
-        "table" : "invoices",
-        "where" : [
-            ["status","=","pending"]
-        ]
+        "database": "local_path_to_db",
+        "table": "invoices",
+        "where": [["status", "=", "pending"]],
     }
 )
 llm = OpenAI()
 df = SmartDatalake(
-        [loan_connector, payment_connector,invoice_connector], 
-        config={"llm": llm}
-    )
+    [loan_connector, payment_connector, invoice_connector], config={"llm": llm}
+)
 response = df.chat("How many people from the United states?")
 print(response)
 # Output: 247 loans have been paid off by men.

--- a/examples/from_sql.py
+++ b/examples/from_sql.py
@@ -2,7 +2,7 @@
 
 from pandasai import SmartDatalake
 from pandasai.llm import OpenAI
-from pandasai.connectors import MySQLConnector, PostgreSQLConnector
+from pandasai.connectors import MySQLConnector, PostgreSQLConnector,SqliteConnector
 
 # With a MySQL database
 loan_connector = MySQLConnector(
@@ -38,8 +38,19 @@ payment_connector = PostgreSQLConnector(
     }
 )
 
+# With a Sqlite databse 
+
+invoice_connector = SqliteConnector(
+    config={
+        "database" : "local_path_to_db",
+        "table" : "invoices",
+        "where" : [
+            ["status","=","pending"]
+        ]
+    }
+)
 llm = OpenAI()
-df = SmartDatalake([loan_connector, payment_connector], config={"llm": llm})
+df = SmartDatalake([loan_connector, payment_connector,invoice_connector], config={"llm": llm})
 response = df.chat("How many people from the United states?")
 print(response)
 # Output: 247 loans have been paid off by men.

--- a/pandasai/connectors/__init__.py
+++ b/pandasai/connectors/__init__.py
@@ -10,6 +10,7 @@ from .snowflake import SnowFlakeConnector
 from .databricks import DatabricksConnector
 from .yahoo_finance import YahooFinanceConnector
 from .airtable import AirtableConnector
+from .sql import SqliteConnector
 
 __all__ = [
     "BaseConnector",
@@ -20,4 +21,5 @@ __all__ = [
     "SnowFlakeConnector",
     "DatabricksConnector",
     "AirtableConnector",
+    "SqliteConnector",
 ]

--- a/pandasai/connectors/base.py
+++ b/pandasai/connectors/base.py
@@ -39,6 +39,15 @@ class SQLBaseConnectorConfig(BaseConnectorConfig):
     dialect: Optional[str] = None
 
 
+class SqliteConnectorConfig(SQLBaseConnectorConfig):
+    """
+    Connector configurations for sqlite db.
+    """
+
+    table: str
+    database: str = "sqlite"
+
+
 class YahooFinanceConnectorConfig(BaseConnectorConfig):
     """
     Connector configuration for Yahoo Finance.

--- a/pandasai/connectors/base.py
+++ b/pandasai/connectors/base.py
@@ -45,7 +45,7 @@ class SqliteConnectorConfig(SQLBaseConnectorConfig):
     """
 
     table: str
-    database: str = "sqlite"
+    database: str
 
 
 class YahooFinanceConnectorConfig(BaseConnectorConfig):

--- a/pandasai/connectors/sql.py
+++ b/pandasai/connectors/sql.py
@@ -442,7 +442,7 @@ class SqliteConnector(SQLConnector):
             str: The string representation of the SQL connector.
         """
         return (
-            f"<{self.__class__.__name__} dialect={self._config.dialect}"
+            f"<{self.__class__.__name__} dialect={self._config.dialect} "
             f"database={self._config.database} "
             f"table={self._config.table}>"
         )

--- a/tests/connectors/test_sqlite.py
+++ b/tests/connectors/test_sqlite.py
@@ -1,0 +1,85 @@
+import unittest
+import pandas as pd
+from unittest.mock import Mock,patch
+from pandasai.connectors.base import SqliteConnectorConfig
+from pandasai.connectors import SqliteConnector
+
+class TestSqliteConnector(unittest.TestCase):
+    @patch("pandasai.connectors.sql.create_engine",autospec=True)
+    def setUp(self,mock_create_engine) -> None:
+        self.mock_engine = Mock()
+        self.mock_connection = Mock()
+        self.mock_engine.connect.return_value = self.mock_connection
+        mock_create_engine.return_value = self.mock_engine
+
+        self.config = SqliteConnectorConfig(
+            dialect="sqlite",
+            database="path_todb.db",
+            table="yourtable"
+        ).dict()
+
+        self.connector = SqliteConnector(self.config)
+
+    @patch("pandasai.connectors.SqliteConnector._load_connector_config")
+    @patch("pandasai.connectors.SqliteConnector._init_connection")
+    def test_constructor_and_properties(
+        self, mock_load_connector_config, mock_init_connection
+    ):
+        # Test constructor and properties
+        self.assertEqual(self.connector._config, self.config)
+        self.assertEqual(self.connector._engine, self.mock_engine)
+        self.assertEqual(self.connector._connection, self.mock_connection)
+        self.assertEqual(self.connector._cache_interval, 600)
+        SqliteConnector(self.config)
+        mock_load_connector_config.assert_called()
+        mock_init_connection.assert_called()
+
+    def test_repr_method(self):
+        # Test __repr__ method
+        expected_repr = (
+            "<SqliteConnector dialect=sqlite "
+            "database=path_todb.db table=yourtable>"
+        )
+        self.assertEqual(repr(self.connector), expected_repr)
+    
+    @patch("pandasai.connectors.sql.pd.read_sql", autospec=True)
+    def test_head_method(self, mock_read_sql):
+        expected_data = pd.DataFrame({"Column1": [1, 2, 3], "Column2": [4, 5, 6]})
+        mock_read_sql.return_value = expected_data
+        head_data = self.connector.head()
+        pd.testing.assert_frame_equal(head_data, expected_data)
+
+    def test_rows_count_property(self):
+        # Test rows_count property
+        self.connector._rows_count = None
+        self.mock_connection.execute.return_value.fetchone.return_value = (
+            50,
+        )  # Sample rows count
+        rows_count = self.connector.rows_count
+        self.assertEqual(rows_count, 50)
+
+    def test_columns_count_property(self):
+        # Test columns_count property
+        self.connector._columns_count = None
+        mock_df = Mock()
+        mock_df.columns = ["Column1", "Column2"]
+        self.connector.head = Mock(return_value=mock_df)
+        columns_count = self.connector.columns_count
+        self.assertEqual(columns_count, 2)
+
+    def test_column_hash_property(self):
+        # Test column_hash property
+        mock_df = Mock()
+        mock_df.columns = ["Column1", "Column2"]
+        self.connector.head = Mock(return_value=mock_df)
+        column_hash = self.connector.column_hash
+        self.assertIsNotNone(column_hash)
+        self.assertEqual(
+            column_hash,
+            "0d045cff164deef81e24b0ed165b7c9c2789789f013902115316cde9d214fe63",
+        )
+
+    def test_fallback_name_property(self):
+        # Test fallback_name property
+        fallback_name = self.connector.fallback_name
+        self.assertEqual(fallback_name, "yourtable")


### PR DESCRIPTION
- [x] closes #650 
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

Added support for sqlite file database. Implemented `SqliteConnector` and `SqliteConnectorConfig` where 
file path can be parsed as `database` key to `config` parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Added support for SQLite databases, expanding the range of databases that can be connected to. Users can now retrieve data from SQLite databases using the new `SqliteConnector`.
- Documentation: Updated the documentation to include examples and usage of the new `SqliteConnector`.
- Test: Introduced unit tests for the `SqliteConnector` to ensure its functionality and reliability.
  
This update enhances the software's versatility by supporting more types of databases, making it more useful for users who work with SQLite databases. It also provides clear instructions and examples for using the new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->