### PR TITLE
feat(openai-callback): add Azure OpenAI fine-tuned models

### DIFF
--- a/pandasai/helpers/openai_info.py
+++ b/pandasai/helpers/openai_info.py
@@ -39,13 +39,51 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-35-turbo-instruct-completion": 0.002,
     "gpt-35-turbo-16k-completion": 0.004,
     "gpt-35-turbo-16k-0613-completion": 0.004,
-    # Others
-    "text-davinci-003": 0.02,
     # Fine-tuned input
     "gpt-3.5-turbo-0613-finetuned": 0.012,
     # Fine-tuned output
     "gpt-3.5-turbo-0613-finetuned-completion": 0.016,
+    # Azure Fine-tuned output
+    "gpt-35-turbo-0613-azure-finetuned": 0.0015,
+    # Azure Fine-tuned output
+    "gpt-35-turbo-0613-azure-finetuned-completion": 0.002,
+    # Others
+    "text-davinci-003": 0.02,
 }
+
+
+def standardize_model_name(
+    model_name: str,
+    is_completion: bool = False,
+) -> str:
+    """
+    Standardize the model name to a format that can be used in the OpenAI API.
+
+    Args:
+        model_name: Model name to standardize.
+        is_completion: Whether the model is used for completion or not.
+            Defaults to False.
+
+    Returns:
+        Standardized model name.
+
+    """
+    model_name = model_name.lower()
+    if ".ft-" in model_name:
+        model_name = model_name.split(".ft-")[0] + "-azure-finetuned"
+    if "ft:" in model_name:
+        model_name = model_name.split(":")[1] + "-finetuned"
+    if is_completion and (
+            model_name.startswith("gpt-4")
+            or model_name.startswith("gpt-3.5")
+            or model_name.startswith("gpt-35")
+            or "finetuned" in model_name
+    ):
+        # The cost of completion token is different from
+        # the cost of prompt tokens.
+        return model_name + "-completion"
+    else:
+        return model_name
 
 
 def get_openai_token_cost_for_model(
@@ -65,18 +103,7 @@ def get_openai_token_cost_for_model(
     Returns:
         float: Cost in USD.
     """
-    model_name = model_name.lower()
-    if "ft:" in model_name:
-        model_name = model_name.split(":")[1] + "-finetuned"
-    if is_completion and (
-        model_name.startswith("gpt-4")
-        or model_name.startswith("gpt-3.5")
-        or model_name.startswith("gpt-35")
-        or "finetuned" in model_name
-    ):
-        # The cost of completion token is different from
-        # the cost of prompt tokens.
-        model_name = model_name + "-completion"
+    model_name = standardize_model_name(model_name, is_completion=is_completion)
     if model_name not in MODEL_COST_PER_1K_TOKENS:
         raise ValueError(
             f"Unknown model: {model_name}. Please provide a valid OpenAI model name."
@@ -107,7 +134,7 @@ class OpenAICallbackHandler:
         if "total_tokens" not in usage:
             return None
 
-        model_name = response.model
+        model_name = standardize_model_name(response.model)
         if model_name in MODEL_COST_PER_1K_TOKENS:
             prompt_cost = get_openai_token_cost_for_model(
                 model_name, usage.prompt_tokens

--- a/tests/helpers/test_openai_info.py
+++ b/tests/helpers/test_openai_info.py
@@ -57,7 +57,105 @@ class TestOpenAIInfo:
         # cost must be 0.0 for unknown model
         assert handler.total_cost == 0.0
 
-    @pytest.mark.skip
+    @pytest.mark.parametrize(
+        "model_name,expected_cost",
+        [
+            ("gpt-3.5-turbo", 0.0035),
+            (
+                "gpt-3.5-turbo-0613",
+                0.0035,
+            ),
+            (
+                "gpt-3.5-turbo-16k-0613",
+                0.007,
+            ),
+            (
+                "gpt-3.5-turbo-16k",
+                0.007,
+            ),
+            ("gpt-4", 0.09),
+            ("gpt-4-0613", 0.09),
+            ("gpt-4-32k", 0.18),
+            ("gpt-4-32k-0613", 0.18),
+        ],
+    )
+    def test_handler_openai(
+        self, handler: OpenAICallbackHandler, model_name: str, expected_cost: float
+    ) -> None:
+        response = OpenAIObject.construct_from(
+            {
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "completion_tokens": 1000,
+                    "total_tokens": 2000,
+                },
+                "model": model_name,
+            }
+        )
+        handler(response)
+        assert handler.total_cost == expected_cost
+
+    @pytest.mark.parametrize(
+        "model_name,expected_cost",
+        [
+            ("gpt-35-turbo", 0.0035),
+            (
+                "gpt-35-turbo-0613",
+                0.0035,
+            ),
+            (
+                "gpt-35-turbo-16k-0613",
+                0.007,
+            ),
+            (
+                "gpt-35-turbo-16k",
+                0.007,
+            ),
+            ("gpt-4", 0.09),
+            ("gpt-4-0613", 0.09),
+            ("gpt-4-32k", 0.18),
+            ("gpt-4-32k-0613", 0.18),
+        ],
+    )
+    def test_handler_azure_openai(
+        self, handler: OpenAICallbackHandler, model_name: str, expected_cost: float
+    ) -> None:
+        response = OpenAIObject.construct_from(
+            {
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "completion_tokens": 1000,
+                    "total_tokens": 2000,
+                },
+                "model": model_name,
+            }
+        )
+        handler(response)
+        assert handler.total_cost == expected_cost
+
+    @pytest.mark.parametrize(
+        "model_name, expected_cost",
+        [
+            ("ft:gpt-3.5-turbo-0613:your-org:custom-model-name:1abcdefg", 0.028),
+            ("gpt-35-turbo-0613.ft-0123456789abcdefghijklmnopqrstuv", 0.0035),
+        ],
+    )
+    def test_handler_finetuned_model(
+        self, handler: OpenAICallbackHandler, model_name: str, expected_cost: float
+    ):
+        response = OpenAIObject.construct_from(
+            {
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "completion_tokens": 1000,
+                    "total_tokens": 2000,
+                },
+                "model": model_name,
+            }
+        )
+        handler(response)
+        assert handler.total_cost == expected_cost
+
     def test_openai_callback(self, mocker):
         df = pd.DataFrame([1, 2, 3])
         llm = OpenAI(api_token="test")


### PR DESCRIPTION
Completion of #682, plus some tests covering the cost computation for both OpenAI and Azure OpenAI - including fine-tuned models.

- [X] Tests added and passed if fixing a bug or adding a new feature
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a function to standardize model names, enhancing the consistency of interactions with the OpenAI API.
- Improvement: Updated the cost calculation and checking process to use the new standardized model names, improving the accuracy of cost estimations.
- Test: Added comprehensive test cases for the OpenAI Callback Handler, increasing the reliability of the system by ensuring it handles various model names and calculates costs correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->