### PR TITLE
fix: initial directories creating

### DIFF
--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -83,9 +83,9 @@ class SmartDatalake:
             logger (Logger, optional): Logger to be used. Defaults to None.
         """
 
-        self.initialize()
-
         self._load_config(config)
+
+        self.initialize()
 
         if logger:
             self.logger = logger
@@ -136,21 +136,30 @@ class SmartDatalake:
         self._query_exec_tracker.set_related_query(flag)
 
     def initialize(self):
-        """Initialize the SmartDatalake"""
+        """Initialize the SmartDatalake, create auxiliary directories.
 
-        # Create exports/charts folder if it doesn't exist
-        try:
-            charts_dir = os.path.join((find_project_root()), "exports", "charts")
-        except ValueError:
-            charts_dir = os.path.join(os.getcwd(), "exports", "charts")
-        os.makedirs(charts_dir, mode=0o777, exist_ok=True)
+        If 'save_charts' option is enabled, create '.exports/charts directory'
+        in case if it doesn't exist.
+        If 'enable_cache' option is enabled, Create './cache' in case if it
+        doesn't exist.
 
-        # Create /cache folder if it doesn't exist
-        try:
-            cache_dir = os.path.join((find_project_root()), "cache")
-        except ValueError:
-            cache_dir = os.path.join(os.getcwd(), "cache")
-        os.makedirs(cache_dir, mode=0o777, exist_ok=True)
+        Returns:
+            None
+        """
+
+        if self._config.save_charts:
+            try:
+                charts_dir = os.path.join((find_project_root()), "exports", "charts")
+            except ValueError:
+                charts_dir = os.path.join(os.getcwd(), "exports", "charts")
+            os.makedirs(charts_dir, mode=0o777, exist_ok=True)
+
+        if self._config.enable_cache:
+            try:
+                cache_dir = os.path.join((find_project_root()), "cache")
+            except ValueError:
+                cache_dir = os.path.join(os.getcwd(), "cache")
+            os.makedirs(cache_dir, mode=0o777, exist_ok=True)
 
     def _load_dfs(self, dfs: List[Union[DataFrameType, Any]]):
         """

--- a/tests/test_smartdatalake.py
+++ b/tests/test_smartdatalake.py
@@ -181,15 +181,28 @@ Correct the python code and return a new python code that fixes the above mentio
 """  # noqa: E501
         )
 
+    @pytest.mark.parametrize(
+        "save_charts,enable_cache",
+        [(False, False), (False, True), (True, False), (True, True)],
+    )
     @patch("os.makedirs")
-    def test_initialize(self, mock_makedirs, smart_datalake: SmartDatalake):
+    def test_initialize(
+        self, mock_makedirs, smart_datalake: SmartDatalake, save_charts, enable_cache
+    ):
+        smart_datalake.config.save_charts = save_charts
+        smart_datalake.config.enable_cache = enable_cache
         smart_datalake.initialize()
 
-        charts_dir = os.path.join(os.getcwd(), "exports", "charts")
-        mock_makedirs.assert_any_call(charts_dir, mode=0o777, exist_ok=True)
+        if not save_charts and not enable_cache:
+            mock_makedirs.assert_not_called()
 
-        cache_dir = os.path.join(os.getcwd(), "cache")
-        mock_makedirs.assert_any_call(cache_dir, mode=0o777, exist_ok=True)
+        if save_charts:
+            charts_dir = os.path.join(os.getcwd(), "exports", "charts")
+            mock_makedirs.assert_any_call(charts_dir, mode=0o777, exist_ok=True)
+
+        if enable_cache:
+            cache_dir = os.path.join(os.getcwd(), "cache")
+            mock_makedirs.assert_any_call(cache_dir, mode=0o777, exist_ok=True)
 
     def test_last_answer_and_reasoning(self, smart_datalake: SmartDatalake):
         llm = FakeLLM(


### PR DESCRIPTION
This PR relates to #654.

1. Replace an order of calling of [`.initiliaze()`](https://github.com/gventuri/pandas-ai/blob/cbed878468bf8569951627799009814b12f8b5bb/pandasai/smart_datalake/__init__.py#L86) and [`._load_config()`](https://github.com/gventuri/pandas-ai/blob/cbed878468bf8569951627799009814b12f8b5bb/pandasai/smart_datalake/__init__.py#L88) methods. This allows the config object to be used in a scope of `.initialize()`, and 'config first' approach looks more correct. 
2. Add clauses in `.initialize()`: create directories for charts only if "save_charts" is passed as True. Same for cache as well.
3. Update tests accordingly.
___

* (fix): do not create directory for charts exporting if 'save_charts' is False
* (fix): do not create directory for cache files if 'enable_cache' is False as well
* (test): update tests accordingly

- [x] closes #654
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Feature: Enhanced the `SmartDatalake` class to conditionally create directories for saving charts and enabling cache based on user preferences. This change provides more flexibility and control to the user.
- Test: Added a new test case to verify the conditional creation of directories in the `SmartDatalake` class. This ensures the robustness of the new feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->