### PR TITLE
fix: add checking type of 'result' (#626)

### DIFF
--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -524,7 +524,20 @@ class SmartDatalake:
         Args:
             result (dict): The result to add to the memory
         """
-        if result is None:
+        if not isinstance(result, dict):
+            self.logger.log(
+                f"Inappropriate type of 'result' produced by generated code. "
+                f"Expected 'dict', got '{result.__class__.__name__}'",
+                level=logging.WARNING,
+            )
+            return
+
+        if "type" not in result or "value" not in result:
+            self.logger.log(
+                f"Both 'type' and 'value' items should be present in 'result' "
+                f"produced by generated code. Instead it contains the next "
+                f"content:\n{result}"
+            )
             return
 
         if result["type"] in ["string", "number"]:


### PR DESCRIPTION
This PR adds an additional verification in `_add_result_to_memory()` of `SmartDatalake`.
Ensure that `result` is actually a dictionary.
Ensure that `result` contains `"type"` and `"value"` the items.

___

* (fix): add checking type of 'result' in '._add_result_to_memory()' method
* (fix): add checking that 'result' dict contains 'type' and 'value' the keys in '._add_result_to_memory()' method

- [x] Related to #626, but not closes it
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced input validation for the data addition process, improving error handling and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->