### PR TITLE
chore(QueryExecTracker): store and get last log id from query tracker

### DIFF
--- a/pandasai/agent/__init__.py
+++ b/pandasai/agent/__init__.py
@@ -209,3 +209,7 @@ class Agent:
     @property
     def last_answer(self):
         return self._lake.last_answer
+
+    @property
+    def last_query_log_id(self):
+        return self._lake.last_query_log_id

--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -703,6 +703,10 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
     def sample_head(self, sample_head: pd.DataFrame):
         self._sample_head = sample_head.to_csv(index=False)
 
+    @property
+    def last_query_log_id(self):
+        return self._lake.last_query_log_id
+
     def __getattr__(self, name):
         if name in self._core.__dir__():
             return getattr(self._core, name)

--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -777,3 +777,7 @@ class SmartDatalake:
     @property
     def instance(self):
         return self._instance
+
+    @property
+    def last_query_log_id(self):
+        return self._query_exec_tracker.last_log_id


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `last_query_log_id` to track the last query log ID across multiple classes.
- **Refactor**
	- Updated `add_query_info` method to accept `conversation_id` as a string.
	- Enhanced `publish` method to parse response and update the last log ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->