### PR TITLE
feat: an update of file system permission (#700)

### DIFF
--- a/pandasai/connectors/sql.py
+++ b/pandasai/connectors/sql.py
@@ -13,6 +13,7 @@ from sqlalchemy.engine import Connection
 from functools import cached_property, cache
 import hashlib
 from ..helpers.path import find_project_root
+from ..constants import DEFAULT_FILE_PERMISSIONS
 from typing import Union
 import time
 
@@ -183,7 +184,7 @@ class SQLConnector(BaseConnector):
         except ValueError:
             cache_dir = os.path.join(os.getcwd(), "cache")
 
-        os.makedirs(cache_dir, mode=0o777, exist_ok=True)
+        os.makedirs(cache_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True)
 
         filename = (
             self._get_column_hash(include_additional_filters=include_additional_filters)

--- a/pandasai/connectors/yahoo_finance.py
+++ b/pandasai/connectors/yahoo_finance.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 from .base import YahooFinanceConnectorConfig, BaseConnector
 import time
 from ..helpers.path import find_project_root
+from ..constants import DEFAULT_FILE_PERMISSIONS
 import hashlib
 
 
@@ -83,7 +84,7 @@ class YahooFinanceConnector(BaseConnector):
         except ValueError:
             cache_dir = os.path.join(os.getcwd(), "cache")
 
-        os.makedirs(cache_dir, mode=0o777, exist_ok=True)
+        os.makedirs(cache_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True)
 
         return os.path.join(cache_dir, f"{self._config.table}_data.parquet")
 

--- a/pandasai/constants.py
+++ b/pandasai/constants.py
@@ -8,6 +8,8 @@ While List Builtin Methods.
 # Default directory to store chart if user doesn't provide any
 DEFAULT_CHART_DIRECTORY = "exports/charts"
 
+DEFAULT_FILE_PERMISSIONS = 0o755
+
 # List of Python builtin libraries that are added to the environment by default.
 WHITELISTED_BUILTINS = [
     "abs",

--- a/pandasai/helpers/cache.py
+++ b/pandasai/helpers/cache.py
@@ -2,6 +2,7 @@ import os
 import glob
 import duckdb
 from .path import find_project_root
+from ..constants import DEFAULT_FILE_PERMISSIONS
 
 
 class Cache:
@@ -22,7 +23,7 @@ class Cache:
             except ValueError:
                 cache_dir = os.path.join(os.getcwd(), "cache")
 
-        os.makedirs(cache_dir, mode=0o777, exist_ok=True)
+        os.makedirs(cache_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True)
 
         self.filepath = os.path.join(cache_dir, f"{filename}.db")
         self.connection = duckdb.connect(self.filepath)

--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -21,7 +21,7 @@ import uuid
 import logging
 import os
 import traceback
-from pandasai.constants import DEFAULT_CHART_DIRECTORY
+from pandasai.constants import DEFAULT_CHART_DIRECTORY, DEFAULT_FILE_PERMISSIONS
 from pandasai.helpers.skills_manager import SkillsManager
 
 from pandasai.skills import skill
@@ -165,14 +165,14 @@ class SmartDatalake:
                     charts_dir = os.path.join(
                         os.getcwd(), self._config.save_charts_path
                     )
-            os.makedirs(charts_dir, mode=0o777, exist_ok=True)
+            os.makedirs(charts_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True)
 
         if self._config.enable_cache:
             try:
                 cache_dir = os.path.join((find_project_root()), "cache")
             except ValueError:
                 cache_dir = os.path.join(os.getcwd(), "cache")
-            os.makedirs(cache_dir, mode=0o777, exist_ok=True)
+            os.makedirs(cache_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True)
 
     def _load_dfs(self, dfs: List[Union[DataFrameType, Any]]):
         """

--- a/tests/test_smartdatalake.py
+++ b/tests/test_smartdatalake.py
@@ -12,6 +12,7 @@ from pandasai import SmartDataframe, SmartDatalake
 from pandasai.helpers.code_manager import CodeManager
 from pandasai.llm.fake import FakeLLM
 from pandasai.middlewares import Middleware
+from pandasai.constants import DEFAULT_FILE_PERMISSIONS
 
 from langchain import OpenAI
 
@@ -192,11 +193,15 @@ Correct the python code and return a new python code that fixes the above mentio
 
         # Assertions for enabling cache
         cache_dir = os.path.join(os.getcwd(), "cache")
-        mock_makedirs.assert_any_call(cache_dir, mode=0o777, exist_ok=True)
+        mock_makedirs.assert_any_call(
+            cache_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True
+        )
 
         # Assertions for saving charts
         charts_dir = os.path.join(os.getcwd(), smart_datalake.config.save_charts_path)
-        mock_makedirs.assert_any_call(charts_dir, mode=0o777, exist_ok=True)
+        mock_makedirs.assert_any_call(
+            charts_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True
+        )
 
     @patch("os.makedirs")
     def test_initialize_without_cache(self, mock_makedirs, smart_datalake):
@@ -209,7 +214,9 @@ Correct the python code and return a new python code that fixes the above mentio
 
         # Assertions for saving charts
         charts_dir = os.path.join(os.getcwd(), smart_datalake.config.save_charts_path)
-        mock_makedirs.assert_called_once_with(charts_dir, mode=0o777, exist_ok=True)
+        mock_makedirs.assert_called_once_with(
+            charts_dir, mode=DEFAULT_FILE_PERMISSIONS, exist_ok=True
+        )
 
     def test_last_answer_and_reasoning(self, smart_datalake: SmartDatalake):
         llm = FakeLLM(


### PR DESCRIPTION
Here we have a small update which introduces a variable named `DEFAULT_FILE_PERMISSIONS` in constants.py and set it's value to `0o755` (`-rwxr-xr-x`).

CC: @gventuri 

___

* (feat): introduce variable for deafult file-system permissions
* (feat): set the default file-system permissions to 755 (Unix style)

- [x] closes #700
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized file permissions across the application by replacing hard-coded values with a new constant `DEFAULT_FILE_PERMISSIONS`.
- **Tests**
	- Updated tests to reflect the new standardized file permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->