### PR TITLE
fix: type hint for property `last_prompt_id`

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -35,6 +35,7 @@ Example:
 """
 import warnings
 from typing import List, Optional, Union, Dict, Type
+import uuid
 import importlib.metadata
 
 import pandas as pd
@@ -236,7 +237,7 @@ class PandasAI:
         return [] if self._dl is None else self._dl.logs
 
     @property
-    def last_prompt_id(self) -> str:
+    def last_prompt_id(self) -> uuid.UUID:
         """Return the id of the last prompt that was run."""
         return None if self._dl is None else self._dl.last_prompt_id
 

--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -19,6 +19,7 @@ Example:
 """
 
 import hashlib
+import uuid
 from io import StringIO
 
 import pandas as pd
@@ -538,7 +539,7 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
         return self.lake.last_prompt
 
     @property
-    def last_prompt_id(self) -> str:
+    def last_prompt_id(self) -> uuid.UUID:
         return self.lake.last_prompt_id
 
     @property

--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -582,7 +582,7 @@ class SmartDatalake:
         return self._llm.last_prompt
 
     @property
-    def last_prompt_id(self) -> str:
+    def last_prompt_id(self) -> uuid.UUID:
         """Return the id of the last prompt that was run."""
         if self._last_prompt_id is None:
             raise ValueError("Pandas AI has not been run yet.")


### PR DESCRIPTION
Had already been [refactoring that a couple of months ago](https://github.com/gventuri/pandas-ai/pull/587/files#diff-786be2fdc80d457ed86c7d296c417693a70a8b6ad3c645be4d24ba8e8f0c41c2R52), but hadn't touched `@property` for the corresponding attribute in `SmartDatalake`, `SmartDataframe`.

It's better to let `last_prompt_id`'s return type be `uuid.UUID` rather than `str`. I understand the uuid indentifier is a text string itself, but python's `uuid.UUID` class is not a subclass of `str`.

___

* (fix): make type hint for the property `.last_prompt_id` to be `uuid.UUID` rather than `str`

___

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `last_prompt_id` property across various components to return a UUID instead of a string for enhanced uniqueness and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->