### PR TITLE
feat(skill): redesign skills and fix code exec env bug

### DIFF
--- a/examples/skills_example.py
+++ b/examples/skills_example.py
@@ -23,7 +23,7 @@ salaries_df = pd.DataFrame(salaries_data)
 @skill
 def plot_salaries(names: list[str], salaries: list[int]):
     """
-    Displays the bar chart having name on x axis and salaries on y axis using streamlit
+    Displays the bar chart having name on x-axis and salaries on y-axis using matplotlib
     Args:
         names (list[str]): Employees' names
         salaries (list[int]): Salaries

--- a/pandasai/agent/__init__.py
+++ b/pandasai/agent/__init__.py
@@ -1,7 +1,6 @@
 import json
 from typing import Union, List, Optional
 
-from pandasai.skills import skill
 from ..helpers.df_info import DataFrameType
 from ..helpers.logger import Logger
 from ..helpers.memory import Memory
@@ -13,6 +12,7 @@ from ..prompts.check_if_relevant_to_conversation import (
     CheckIfRelevantToConversationPrompt,
 )
 from ..schemas.df_config import Config
+from ..skills import Skill
 from ..smart_datalake import SmartDatalake
 
 
@@ -49,7 +49,7 @@ class Agent:
 
         self._logger = self._lake.logger
 
-    def add_skills(self, *skills: List[skill]):
+    def add_skills(self, *skills: Skill):
         """
         Add Skills to PandasAI
         """

--- a/pandasai/helpers/code_manager.py
+++ b/pandasai/helpers/code_manager.py
@@ -32,7 +32,6 @@ class CodeExecutionContext:
         Args:
             prompt_id (uuid.UUID): Prompt ID
             skills_manager (SkillsManager): Skills Manager
-            can_direct_sql (bool, optional): Whether the code can be executed as SQL query. Defaults to False.
         """
         self._skills_manager = skills_manager
         self._prompt_id = prompt_id
@@ -51,7 +50,7 @@ class CodeManager:
     _config: Union[Config, dict]
     _logger: Logger = None
     _additional_dependencies: List[dict] = []
-    _ast_comparatos_map: dict = {
+    _ast_comparator_map: dict = {
         ast.Eq: "=",
         ast.NotEq: "!=",
         ast.Lt: "<",
@@ -119,7 +118,7 @@ class CodeManager:
         """
         return re.sub(r"""(['"])([^'"]*\.png)\1""", r"\1temp_chart.png\1", code)
 
-    def _validate_direct_sql(self, dfs: List) -> None:
+    def _validate_direct_sql(self, dfs: List) -> bool:
         """
         Raises error if they don't belong sqlconnector or have different credentials
         Args:
@@ -198,7 +197,7 @@ Code running:
         if self._validate_direct_sql(self._dfs):
             environment["execute_sql_query"] = self._dfs[0].get_query_exec_func()
 
-        # Add Skills in the env
+        # Add skills to the env
         if context.skills_manager.used_skills:
             for skill_func_name in context.skills_manager.used_skills:
                 skill = context.skills_manager.get_skill_by_func_name(skill_func_name)
@@ -558,7 +557,7 @@ Code running:
                     left_str = node.left.args[0].value
 
                     for op, right in zip(node.ops, node.comparators):
-                        op_str = self._ast_comparatos_map.get(type(op), "Unknown")
+                        op_str = self._ast_comparator_map.get(type(op), "Unknown")
                         right_str = right.value
 
                         comparisons[current_df].append((left_str, op_str, right_str))
@@ -573,7 +572,7 @@ Code running:
                     left_str = slices[-1] if slices else name
 
                     for op, right in zip(node.ops, node.comparators):
-                        op_str = self._ast_comparatos_map.get(type(op), "Unknown")
+                        op_str = self._ast_comparator_map.get(type(op), "Unknown")
                         name, *slices = self._tokenize_operand(right)
                         right_str = slices[-1] if slices else name
 

--- a/pandasai/helpers/skills_manager.py
+++ b/pandasai/helpers/skills_manager.py
@@ -64,11 +64,7 @@ class SkillsManager:
         Returns:
             str: _description_
         """
-        skills_repr = ""
-        for skill in self._skills:
-            skills_repr += str(skill)
-
-        return skills_repr
+        return "".join(str(skill) for skill in self._skills)
 
     def prompt_display(self) -> Optional[str]:
         """

--- a/pandasai/helpers/skills_manager.py
+++ b/pandasai/helpers/skills_manager.py
@@ -1,6 +1,5 @@
-from typing import List
-
-# from pandasai.skills import skill
+from typing import List, Optional
+from pandasai.skills import Skill
 
 
 class SkillsManager:
@@ -15,7 +14,7 @@ class SkillsManager:
         self._skills = []
         self._used_skills = []
 
-    def add_skills(self, *skills):
+    def add_skills(self, *skills: Skill):
         """
         Add skills to the list of skills. If a skill with the same name
              already exists, raise an error.
@@ -67,19 +66,19 @@ class SkillsManager:
         """
         skills_repr = ""
         for skill in self._skills:
-            skills_repr = skills_repr + skill.print
+            skills_repr += str(skill)
 
         return skills_repr
 
-    def prompt_display(self) -> str:
+    def prompt_display(self) -> Optional[str]:
         """
         Displays skills for prompt
         """
         if len(self._skills) == 0:
-            return
+            return None
 
-        return """You can call the following functions that have been pre-defined for you:
-""" + self.__str__()
+        return f"You can call the following functions that have been pre-defined for you:\n{self}"
+
 
     @property
     def used_skills(self):

--- a/pandasai/helpers/skills_manager.py
+++ b/pandasai/helpers/skills_manager.py
@@ -79,7 +79,6 @@ class SkillsManager:
 
         return f"You can call the following functions that have been pre-defined for you:\n{self}"
 
-
     @property
     def used_skills(self):
         return self._used_skills

--- a/pandasai/skills/__init__.py
+++ b/pandasai/skills/__init__.py
@@ -1,32 +1,103 @@
+from pydantic import BaseModel, Field, PrivateAttr
+from typing import Callable, Any, Optional, Union
 import inspect
 
 
-def skill(skill_function):
-    def wrapped_function(*args, **kwargs):
-        return skill_function(*args, **kwargs)
+class Skill(BaseModel):
+    """Skill that takes a function usable by pandasai"""
 
-    wrapped_function.name = skill_function.__name__
-    wrapped_function.func_def = (
-        """def pandasai.skills.{funcion_name}{signature}""".format(
-            funcion_name=wrapped_function.name,
-            signature=str(inspect.signature(skill_function)),
-        )
-    )
+    func: Callable[..., Any]
+    name: Optional[str] = Field(default=None)
+    description: Optional[str] = None
+    _signature: Optional[str] = PrivateAttr()
 
-    doc_string = skill_function.__doc__
+    def __call__(self, *args, **kwargs) -> Any:
+        if not self.func:
+            raise ValueError("Must provide a function to this skill.")
+        return self.func(*args, **kwargs)
 
-    wrapped_function.print = (
+    @classmethod
+    def from_function(
+            cls,
+            func: Callable,
+            name: Optional[str] = None,
+            description: Optional[str] = None,
+    ) -> "Skill":
         """
-<function>
-{signature}
-{doc_string}
-</function>
-"""
-    ).format(
-        signature=wrapped_function.func_def,
-        doc_string="""    \"\"\"{0}\n    \"\"\"""".format(doc_string)
-        if doc_string is not None
-        else "",
-    )
+        Creates a skill object from a function
 
-    return wrapped_function
+        Args:
+            func: The function from which to create a skill
+            name: The name of the skill. Defaults to the function name
+            description: The description of the skill. Defaults to the function docstring.
+
+        Returns:
+            the `Skill` object
+
+        """
+        signature = """def pandasai.skills.{function_name}{signature}""".format(
+            function_name=func.__name__,
+            signature=str(inspect.signature(func)),
+        )
+
+        name = name or func.__name__
+        description = description or func.__doc__
+        if description is None:
+            # if description is None then the function doesn't have a docstring
+            # and the user didn't provide any description
+            raise ValueError(
+                f"Function must have a docstring if no description is provided for skill {name}."
+            )
+        cls._signature = signature
+
+        return cls(name=name, description=description, func=func)
+
+    def __str__(self):
+        return f"""
+<function>
+{self._signature}
+    \"\"\"{self.description}\"\"\"
+</function>"""
+
+
+def skill(*args: Union[str, Callable]) -> Callable:
+    """Decorator to create a skill out of functions
+    Can be used without arguments. The function must have a docstring.
+
+    Args:
+        *args: The arguments to the skill
+
+    Examples:
+        .. code-block:: python
+
+            @skill
+            def compute_flight_prices(offers: pd.Dataframe) -> List[float]:
+                # Computes the flight prices
+                return
+
+            @skill("custom_name")
+            def compute_flight_prices(offers: pd.Dataframe) -> List[float]:
+                # Computes the flight prices
+                return
+
+    """
+
+    def _make_skill_with_name(skill_name: str) -> Callable:
+        def _make_skill(skill_fn: Callable) -> Skill:
+            return Skill.from_function(
+                name=skill_name,  # func.__name__ if None
+                # when this decorator is used, the function MUST have a docstring
+                description=skill_fn.__doc__,
+                func=skill_fn,
+            )
+
+        return _make_skill
+
+    if len(args) == 1 and isinstance(args[0], str):
+        # Example: @skill("skillName")
+        return _make_skill_with_name(args[0])
+    elif len(args) == 1 and callable(args[0]):
+        # Example: @skill
+        return _make_skill_with_name(args[0].__name__)(args[0])
+    else:
+        raise ValueError("Too many arguments for skill decorator")

--- a/pandasai/skills/__init__.py
+++ b/pandasai/skills/__init__.py
@@ -18,10 +18,10 @@ class Skill(BaseModel):
 
     @classmethod
     def from_function(
-            cls,
-            func: Callable,
-            name: Optional[str] = None,
-            description: Optional[str] = None,
+        cls,
+        func: Callable,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
     ) -> "Skill":
         """
         Creates a skill object from a function

--- a/pandasai/skills/__init__.py
+++ b/pandasai/skills/__init__.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel, Field, PrivateAttr
-from typing import Callable, Any, Optional, Union
+from abc import abstractmethod
+
+from pydantic import BaseModel, PrivateAttr
+from typing import Callable, Any, Optional
 import inspect
 
 
@@ -7,8 +9,8 @@ class Skill(BaseModel):
     """Skill that takes a function usable by pandasai"""
 
     func: Callable[..., Any]
-    name: Optional[str] = Field(default=None)
     description: Optional[str] = None
+    _name: Optional[str] = PrivateAttr()
     _signature: Optional[str] = PrivateAttr()
 
     def __call__(self, *args, **kwargs) -> Any:
@@ -20,7 +22,6 @@ class Skill(BaseModel):
     def from_function(
         cls,
         func: Callable,
-        name: Optional[str] = None,
         description: Optional[str] = None,
     ) -> "Skill":
         """
@@ -28,19 +29,19 @@ class Skill(BaseModel):
 
         Args:
             func: The function from which to create a skill
-            name: The name of the skill. Defaults to the function name
             description: The description of the skill. Defaults to the function docstring.
 
         Returns:
             the `Skill` object
 
         """
-        signature = """def pandasai.skills.{function_name}{signature}""".format(
-            function_name=func.__name__,
-            signature=str(inspect.signature(func)),
+        name = func.__name__
+        sig = str(inspect.signature(func))
+        signature = """def {function_name}{signature}:""".format(
+            function_name=name,
+            signature=sig,
         )
 
-        name = name or func.__name__
         description = description or func.__doc__
         if description is None:
             # if description is None then the function doesn't have a docstring
@@ -49,8 +50,9 @@ class Skill(BaseModel):
                 f"Function must have a docstring if no description is provided for skill {name}."
             )
         cls._signature = signature
+        cls._name = name
 
-        return cls(name=name, description=description, func=func)
+        return cls(description=description, func=func)
 
     def __str__(self):
         return f"""
@@ -59,10 +61,14 @@ class Skill(BaseModel):
     \"\"\"{self.description}\"\"\"
 </function>"""
 
+    @property
+    def name(self) -> str:
+        return self._name
 
-def skill(*args: Union[str, Callable]) -> Callable:
+
+def skill(*args: Callable) -> Callable:
     """Decorator to create a skill out of functions
-    Can be used without arguments. The function must have a docstring.
+    Must be used without arguments. The function must have a docstring.
 
     Args:
         *args: The arguments to the skill
@@ -74,30 +80,16 @@ def skill(*args: Union[str, Callable]) -> Callable:
             def compute_flight_prices(offers: pd.Dataframe) -> List[float]:
                 # Computes the flight prices
                 return
-
-            @skill("custom_name")
-            def compute_flight_prices(offers: pd.Dataframe) -> List[float]:
-                # Computes the flight prices
-                return
-
     """
 
-    def _make_skill_with_name(skill_name: str) -> Callable:
-        def _make_skill(skill_fn: Callable) -> Skill:
-            return Skill.from_function(
-                name=skill_name,  # func.__name__ if None
-                # when this decorator is used, the function MUST have a docstring
-                description=skill_fn.__doc__,
-                func=skill_fn,
-            )
+    def _make_skill(skill_fn: Callable) -> Skill:
+        return Skill.from_function(
+            # when this decorator is used, the function MUST have a docstring
+            description=skill_fn.__doc__,
+            func=skill_fn,
+        )
 
-        return _make_skill
-
-    if len(args) == 1 and isinstance(args[0], str):
-        # Example: @skill("skillName")
-        return _make_skill_with_name(args[0])
-    elif len(args) == 1 and callable(args[0]):
-        # Example: @skill
-        return _make_skill_with_name(args[0].__name__)(args[0])
+    if len(args) == 1 and callable(args[0]):
+        return _make_skill(args[0])
     else:
         raise ValueError("Too many arguments for skill decorator")

--- a/pandasai/skills/__init__.py
+++ b/pandasai/skills/__init__.py
@@ -1,5 +1,3 @@
-from abc import abstractmethod
-
 from pydantic import BaseModel, PrivateAttr
 from typing import Callable, Any, Optional
 import inspect

--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -27,7 +27,7 @@ from functools import cached_property
 import pydantic
 
 from pandasai.helpers.df_validator import DfValidator
-from pandasai.skills import skill
+from ..skills import Skill
 
 from ..smart_datalake import SmartDatalake
 from ..schemas.df_config import Config
@@ -233,7 +233,7 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
 
     def __init__(
         self,
-        df: DataFrameType,
+        df: Union[DataFrameType, BaseConnector],
         name: str = None,
         description: str = None,
         custom_head: pd.DataFrame = None,
@@ -242,7 +242,7 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
     ):
         """
         Args:
-            df (Union[pd.DataFrame, pl.DataFrame]): Pandas or Polars dataframe
+            df: A supported dataframe type, or a pandasai Connector
             name (str, optional): Name of the dataframe. Defaults to None.
             description (str, optional): Description of the dataframe. Defaults to "".
             custom_head (pd.DataFrame, optional): Sample head of the dataframe.
@@ -289,7 +289,7 @@ class SmartDataframe(DataframeAbstract, Shortcuts):
         if custom_head is not None:
             self._custom_head = custom_head.to_csv(index=False)
 
-    def add_skills(self, *skills: List[skill]):
+    def add_skills(self, *skills: Skill):
         """
         Add Skills to PandasAI
         """

--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -23,7 +23,7 @@ import os
 from pandasai.constants import DEFAULT_CHART_DIRECTORY, DEFAULT_FILE_PERMISSIONS
 from pandasai.helpers.skills_manager import SkillsManager
 from pandasai.pipelines.pipeline_context import PipelineContext
-from pandasai.skills import skill
+from pandasai.skills import Skill
 from pandasai.helpers.query_exec_tracker import QueryExecTracker
 from ..pipelines.smart_datalake_chat.generate_smart_datalake_pipeline import (
     GenerateSmartDatalakePipeline,
@@ -243,7 +243,7 @@ class SmartDatalake:
         if data_viz_library in (item.value for item in VisualizationLibrary):
             self._data_viz_library = data_viz_library
 
-    def add_skills(self, *skills: List[skill]):
+    def add_skills(self, *skills: Skill):
         """
         Add Skills to PandasAI
         """

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -9,7 +9,7 @@ from pandasai.helpers.code_manager import CodeExecutionContext, CodeManager
 
 from pandasai.helpers.skills_manager import SkillsManager
 from pandasai.llm.fake import FakeLLM
-from pandasai.skills import skill
+from pandasai.skills import skill, Skill
 from pandasai.smart_dataframe import SmartDataframe
 
 
@@ -79,8 +79,14 @@ class TestSkills:
 
     def test_add_skills(self):
         skills_manager = SkillsManager()
-        skill1 = Mock(name="SkillA", print="SkillA Print")
-        skill2 = Mock(name="SkillB", print="SkillB Print")
+
+        @skill("SkillA")
+        def skill1():
+            """SkillA docstring"""
+            pass
+
+        skill2 = Skill.from_function(func=lambda _: None, description="Skill B")
+
         skills_manager.add_skills(skill1, skill2)
 
         # Ensure that skills are added
@@ -154,8 +160,8 @@ class TestSkills:
         # Test prompt_display method when skills exist
         prompt = skills_manager.prompt_display()
         assert (
-            "You can call the following functions that have been pre-defined for you:"
-            in prompt
+                "You can call the following functions that have been pre-defined for you:"
+                in prompt
         )
 
         # Test prompt_display method when no skills exist
@@ -164,41 +170,7 @@ class TestSkills:
         assert prompt is None
 
     @patch("pandasai.skills.inspect.signature", return_value="(a, b, c)")
-    def test_skill_decorator(self, mock_inspect_signature):
-        # Define skills using the decorator
-        @skill
-        def skill_a(*args, **kwargs):
-            return "SkillA Result"
-
-        @skill
-        def skill_b(*args, **kwargs):
-            return "SkillB Result"
-
-        # Test the wrapped functions
-        assert skill_a() == "SkillA Result"
-        assert skill_b() == "SkillB Result"
-
-        # Test the additional attributes added by the decorator
-        assert skill_a.name == "skill_a"
-        assert skill_b.name == "skill_b"
-
-        assert skill_a.func_def == "def pandasai.skills.skill_a(a, b, c)"
-        assert skill_b.func_def == "def pandasai.skills.skill_b(a, b, c)"
-
-        assert (
-            skill_a.print
-            == """\n<function>\ndef pandasai.skills.skill_a(a, b, c)\n\n</function>\n"""  # noqa: E501
-        )
-        assert (
-            skill_b.print
-            == """\n<function>\ndef pandasai.skills.skill_b(a, b, c)\n\n</function>\n"""  # noqa: E501
-        )
-
-    @patch("pandasai.skills.inspect.signature", return_value="(a, b, c)")
-    def test_skill_decorator_test_codc(self, llm):
-        df = pd.DataFrame({"country": []})
-        df = SmartDataframe(df, config={"llm": llm, "enable_cache": False})
-
+    def test_skill_decorator_test_code(self, llm):
         # Define skills using the decorator
         @skill
         def plot_salaries(*args, **kwargs):
@@ -215,17 +187,18 @@ class TestSkills:
                 arg(str)
 """  # noqa: E501
 
-        assert function_def in plot_salaries.print
+        assert function_def in str(plot_salaries)
 
     def test_add_skills_with_agent(self, agent: Agent):
-        # Define skills using the decorator
         @skill
         def skill_a(*args, **kwargs):
+            """Skill A"""
             return "SkillA Result"
 
-        @skill
-        def skill_b(*args, **kwargs):
-            return "SkillB Result"
+        skill_b = Skill.from_function(
+            func=lambda _: "SkillB Result",
+            description="Skill B"
+        )
 
         agent.add_skills(skill_a)
         assert len(agent._lake._skills.skills) == 1
@@ -235,14 +208,15 @@ class TestSkills:
         assert len(agent._lake._skills.skills) == 2
 
     def test_add_skills_with_smartDataframe(self, smart_dataframe: SmartDataframe):
-        # Define skills using the decorator
         @skill
         def skill_a(*args, **kwargs):
+            """Skill A"""
             return "SkillA Result"
 
-        @skill
-        def skill_b(*args, **kwargs):
-            return "SkillB Result"
+        skill_b = Skill.from_function(
+            func=lambda _: "SkillB Result",
+            description="Skill B"
+        )
 
         smart_dataframe.add_skills(skill_a)
         assert len(smart_dataframe._lake._skills.skills) == 1
@@ -257,13 +231,14 @@ class TestSkills:
 
         function_def = """
 <function>
-def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame) -> str
-
+def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame)
+    \"\"\"Plot salaries given a dataframe of employees and their salaries\"\"\"
 </function>
 """  # noqa: E501
 
         @skill
-        def plot_salaries(merged_df: pd.DataFrame) -> str:
+        def plot_salaries(merged_df: pd.DataFrame):
+            """Plot salaries given a dataframe of employees and their salaries"""
             import matplotlib.pyplot as plt
 
             plt.bar(merged_df["Name"], merged_df["Salary"])
@@ -283,13 +258,14 @@ def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame) -> str
     def test_run_prompt_agent(self, agent):
         function_def = """
 <function>
-def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame) -> str
-
+def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame)
+    \"\"\"Plot salaries given a dataframe of employees and their salaries\"\"\"
 </function>
 """  # noqa: E501
 
         @skill
-        def plot_salaries(merged_df: pd.DataFrame) -> str:
+        def plot_salaries(merged_df: pd.DataFrame):
+            """Plot salaries given a dataframe of employees and their salaries"""
             import matplotlib.pyplot as plt
 
             plt.bar(merged_df["Name"], merged_df["Salary"])
@@ -315,12 +291,12 @@ def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame) -> str
         assert "<function>" not in last_prompt
         assert "</function>" not in last_prompt
         assert (
-            "You can call the following functions that have been pre-defined for you:"
-            not in last_prompt
+                "You can call the following functions that have been pre-defined for you:"
+                not in last_prompt
         )
 
     def test_code_exec_with_skills_no_use(
-        self, code_manager: CodeManager, exec_context
+            self, code_manager: CodeManager, exec_context
     ):
         code = """result = {'type': 'number', 'value': 1 + 1}"""
         skill1 = MagicMock()
@@ -335,6 +311,7 @@ result = {'type': 'number', 'value': 1 + 1}"""
 
         @skill
         def plot_salaries() -> str:
+            """Plots salaries"""
             return "return {'type': 'number', 'value': 1 + 1}"
 
         sm = SkillsManager()

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -80,7 +80,7 @@ class TestSkills:
     def test_add_skills(self):
         skills_manager = SkillsManager()
 
-        @skill("SkillA")
+        @skill
         def skill1():
             """SkillA docstring"""
             pass
@@ -231,7 +231,7 @@ class TestSkills:
 
         function_def = """
 <function>
-def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame)
+def plot_salaries(merged_df: pandas.core.frame.DataFrame):
     \"\"\"Plot salaries given a dataframe of employees and their salaries\"\"\"
 </function>
 """  # noqa: E501
@@ -258,7 +258,7 @@ def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame)
     def test_run_prompt_agent(self, agent):
         function_def = """
 <function>
-def pandasai.skills.plot_salaries(merged_df: pandas.core.frame.DataFrame)
+def plot_salaries(merged_df: pandas.core.frame.DataFrame):
     \"\"\"Plot salaries given a dataframe of employees and their salaries\"\"\"
 </function>
 """  # noqa: E501


### PR DESCRIPTION
Hi @gventuri,
this PR aims at making `Skill` a proper, pythonic type while supporting a (proper) decorator. This new implementation requires (purposely) the function to have a docstring when decorated with `@skill`. In addition, one can create a skill as follows

```py
skill = Skill.from_function(func=some_func, description=...)
```

- [X] Tests added and passed if fixing a bug or adding a new feature
- [X] Closes #839 
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for adding skills to the system.
  - Enhanced the logic for SQL comparison extraction.
  - Improved the `Skill` class with new creation methods and properties.
  - Updated the handling of skills within the SmartDataframe class.

- **Bug Fixes**
  - Fixed incorrect type hints and method return types.

- **Tests**
  - Refined test cases for skill addition and prompt display functionalities.

- **Documentation**
  - Added docstrings to clarify the purpose of test functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->