### PR TITLE
feat(skills): handle no args passed to decorator

### DIFF
--- a/pandasai/skills/__init__.py
+++ b/pandasai/skills/__init__.py
@@ -116,4 +116,6 @@ def skill(*args: Union[str, Callable]) -> Callable:
             return _make_skill_with_name(fn.__name__)(fn)
         return _func_wrapper
     else:
-        raise ValueError(f"Too many arguments for skill decorator. Received: {len(args)}")
+        raise ValueError(
+            f"Too many arguments for skill decorator. Received: {len(args)}"
+        )

--- a/pandasai/skills/__init__.py
+++ b/pandasai/skills/__init__.py
@@ -80,10 +80,12 @@ def skill(*args: Union[str, Callable]) -> Callable:
 
     Examples:
         .. code-block:: python
+
             @skill
             def compute_flight_prices(offers: pd.Dataframe) -> List[float]:
                 \"\"\"Computes the flight prices\"\"\"
                 return
+
             @skill("custom_name")
             def compute_flight_prices(offers: pd.Dataframe) -> List[float]:
                 \"\"\"Computes the flight prices\"\"\"
@@ -107,5 +109,11 @@ def skill(*args: Union[str, Callable]) -> Callable:
     elif len(args) == 1 and callable(args[0]):
         # Example: @skill
         return _make_skill_with_name(args[0].__name__)(args[0])
+    elif len(args) == 0:
+        # Covers the case in which a function is decorated with "@skill()"
+        # with the intended behavior of "@skill"
+        def _func_wrapper(fn: Callable) -> Skill:
+            return _make_skill_with_name(fn.__name__)(fn)
+        return _func_wrapper
     else:
-        raise ValueError("Too many arguments for skill decorator")
+        raise ValueError(f"Too many arguments for skill decorator. Received: {len(args)}")

--- a/pandasai/skills/__init__.py
+++ b/pandasai/skills/__init__.py
@@ -114,6 +114,7 @@ def skill(*args: Union[str, Callable]) -> Callable:
         # with the intended behavior of "@skill"
         def _func_wrapper(fn: Callable) -> Skill:
             return _make_skill_with_name(fn.__name__)(fn)
+
         return _func_wrapper
     else:
         raise ValueError(


### PR DESCRIPTION
Hi @gventuri and happy New Year!
This small PR just aims at covering a case in which I've accidentally ran into this morning: decorating a skill like this `@skill()` with the intended behavior of `@skill` (no brackets). 

In addition, this PR fixes the formatting of the decorator's docstring in the documentation (not properly displayed in the latest version).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

The existing bullet-point list is still valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->