### PR TITLE
fix: cache dir when 'enable_cache' is False (#838)

### DIFF
--- a/pandasai/pipelines/pipeline_context.py
+++ b/pandasai/pipelines/pipeline_context.py
@@ -16,7 +16,7 @@ class PipelineContext:
     _dfs: List[Union[DataFrameType, Any]]
     _memory: Memory
     _skills: SkillsManager
-    _cache: Cache
+    _cache: Optional[Cache]
     _config: Config
     _query_exec_tracker: QueryExecTracker
     _intermediate_values: dict
@@ -25,10 +25,10 @@ class PipelineContext:
         self,
         dfs: List[Union[DataFrameType, Any]],
         config: Optional[Union[Config, dict]] = None,
-        memory: Memory = None,
-        skills: SkillsManager = None,
-        cache: Cache = None,
-        query_exec_tracker: QueryExecTracker = None,
+        memory: Optional[Memory] = None,
+        skills: Optional[SkillsManager] = None,
+        cache: Optional[Cache] = None,
+        query_exec_tracker: Optional[QueryExecTracker] = None,
     ) -> None:
         from pandasai.smart_dataframe import load_smartdataframes
 
@@ -38,7 +38,10 @@ class PipelineContext:
         self._dfs = load_smartdataframes(dfs, config)
         self._memory = memory if memory is not None else Memory()
         self._skills = skills if skills is not None else SkillsManager()
-        self._cache = cache if cache is not None else Cache()
+        if config.enable_cache:
+            self._cache = cache if cache is not None else Cache()
+        else:
+            self._cache = None
         self._config = config
         self._query_exec_tracker = query_exec_tracker
         self._intermediate_values = {}

--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -7,10 +7,10 @@ Example:
     ```python
     from pandasai.smart_dataframe import SmartDataframe
     from pandasai.llm.openai import OpenAI
-    
+
     df = pd.read_csv("examples/data/Loan payments data.csv")
     llm = OpenAI()
-    
+
     df = SmartDataframe(df, config={"llm": llm})
     response = df.chat("What is the average loan amount?")
     print(response)
@@ -73,9 +73,9 @@ class SmartDatalake:
         self,
         dfs: List[Union[DataFrameType, Any]],
         config: Optional[Union[Config, dict]] = None,
-        logger: Logger = None,
-        memory: Memory = None,
-        cache: Cache = None,
+        logger: Optional[Logger] = None,
+        memory: Optional[Memory] = None,
+        cache: Optional[Cache] = None,
     ):
         """
         Args:


### PR DESCRIPTION
Here is a verbal description of what i've done:

1. Add [conditional creating of `_cache` attribute](https://github.com/gventuri/pandas-ai/blob/f8ce94f8216696f595dae52ce10c3e77fdbe5755/pandasai/pipelines/pipeline_context.py#L41) (if `enable_cache` in the config obj is False, then we left it to be `None`).
2. Update type hints [here](https://github.com/gventuri/pandas-ai/blob/f8ce94f8216696f595dae52ce10c3e77fdbe5755/pandasai/pipelines/pipeline_context.py#L19), [here](https://github.com/gventuri/pandas-ai/blob/f8ce94f8216696f595dae52ce10c3e77fdbe5755/pandasai/pipelines/pipeline_context.py#L28) and [here in `SmartDatalake`](https://github.com/gventuri/pandas-ai/blob/f8ce94f8216696f595dae52ce10c3e77fdbe5755/pandasai/smart_datalake/__init__.py#L76), so, when we expecting and attribute or an argument **is allowed to be** 'None', we should add `Optional[SomeType]` (shortcut `Union[None, SomeType]`)

___

* (fix): suppress creating cache dir ('Cache' object essentially) when 'enable_cache' is False in 'PipelineContext' __init__() method
* (refactor): add 'Optional' type for lots of methods parameters in 'PipelineContext' methods and 'SmartDatalake' methods as well

___

- [x] closes #838
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `PipelineContext` to handle optional settings for enhanced flexibility.
  - Modified initialization parameters to allow optional configuration in the Smart Data Lake initialization.

- **New Features**
  - Integrated new import functionality to expand data processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->