### PR TITLE
(refactor): built-in shadowing in SmartDatalake

### DIFF
--- a/pandasai/smart_datalake/__init__.py
+++ b/pandasai/smart_datalake/__init__.py
@@ -129,8 +129,8 @@ class SmartDatalake:
             server_config=self._config.log_server,
         )
 
-    def set_instance_type(self, type: str):
-        self._instance = type
+    def set_instance_type(self, type_: str):
+        self._instance = type_
 
     def is_related_query(self, flag: bool):
         self._query_exec_tracker.set_related_query(flag)


### PR DESCRIPTION
It's better to aviod built-in names shadowing in most cases when working with Python. Modern Python's PEP08 ([Descriptive: Naming Styles](https://peps.python.org/pep-0008/#descriptive-naming-styles)) suggests using a trailing underscore:

> `single_trailing_underscore_`: used by convention to avoid conflicts with Python keyword

Although they're talking about keywords there, the same approach perfectly fits for lots of naming conflicts, like with built-ins in our case.

___

Btw, old known `_leading_underscore` originally had been used for the same purpose, when Python 2 was popular. Later people added different meaning related to information hiding principle (which essentially absent in Python till nowadays, i mean, "protected attribute", all those things, so it's based on a developers agreement).

___

* (refactor): avoid built-in names shadowing in `set_instance_type()` method of `SmartDatalake`

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated parameter naming to enhance compatibility and avoid conflicts with reserved keywords in the data management interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->