### PR TITLE
chore: relaxing sqlalchemy versions to include 2.x.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ openai = "<2"
 ipython = "^8.13.1"
 matplotlib = "^3.7.1"
 pydantic = "^1"
-sqlalchemy = "^1.4.49,<3"
+sqlalchemy = ">=1.4,<3"
 duckdb = "^0.8.1"
 faker = "^19.12.0"
 beautifulsoup4 = {version="^4.12.2", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ openai = "<2"
 ipython = "^8.13.1"
 matplotlib = "^3.7.1"
 pydantic = "^1"
-sqlalchemy = "^1.4.49"
+sqlalchemy = "^1.4.49,<3"
 duckdb = "^0.8.1"
 faker = "^19.12.0"
 beautifulsoup4 = {version="^4.12.2", optional = true}


### PR DESCRIPTION
Relaxing `sqlalchemy` requirements to allow usage of sqlalchemy 2.x.

- [x] Closes #853 (Replace xxxx with the GitHub issue number).
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).
