### PR TITLE
[fix] logging chart saving only if code contains chart

### DIFF
--- a/pandasai/helpers/save_chart.py
+++ b/pandasai/helpers/save_chart.py
@@ -23,7 +23,6 @@ def add_save_chart(
         str: Code with line added.
 
     """
-
     save_charts_path = Path(save_charts_path_str) if save_charts_path_str else None
 
     if save_charts_path is not None:
@@ -31,7 +30,8 @@ def add_save_chart(
 
         save_charts_file = save_charts_path / f"{file_name}.png"
 
-        code = code.replace("temp_chart.png", save_charts_file.as_posix())
-        logger.log(f"Saving charts to {save_charts_file}")
+        if "temp_chart.png" in code:
+            code = code.replace("temp_chart.png", save_charts_file.as_posix())
+            logger.log(f"Saving charts to {save_charts_file}")
 
     return code


### PR DESCRIPTION
- [x] Closes #894  (Replace xxxx with the GitHub issue number).
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

This is a simple fix where we prevent the logger to log "saving charts" when the code itself is not about charts.
We simply check if we have the default chart name in the code, and replace it by chart file name and log if it does.

I tried to create a const to save the default file name, but the sourcery complains, so we can keep simple and just test the string.

Possible reviewer @gventuri 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the chart saving functionality by ensuring temporary chart names are correctly replaced with designated file paths, enhancing the reliability of chart generation and saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->