### PR TITLE
feat: relax pyarrow dependency constraint to support versions up to 19.x

### DIFF
--- a/extensions/connectors/yfinance/pyproject.toml
+++ b/extensions/connectors/yfinance/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = ">=3.9,<3.12"
 pandasai = ">=3.0.0b4"
 yfinance = "^0.2.35"
-pyarrow = "^14.0.1"
+pyarrow = ">=14.0.1,<19.0.0"
 
 [tool.poetry.group.test]
 optional = true

--- a/extensions/ee/connectors/databricks/pyproject.toml
+++ b/extensions/ee/connectors/databricks/pyproject.toml
@@ -14,7 +14,7 @@ license = "Proprietary"
 python = ">=3.9,<3.12"
 pandasai = ">=3.0.0b4"
 pandasai-sql = "^0.1.0"
-pyarrow = "^14.0.1"
+pyarrow = ">=14.0.1,<19.0.0"
 databricks-sql-connector = {extras = ["sqlalchemy"], version = "^3.6.0"}
 
 [tool.poetry.group.test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ numpy = "^1.17"
 openpyxl = "^3.1.5"
 seaborn = "^0.12.2"
 sqlglot = "^25.0.3" 
-pyarrow = "^14.0.1"
+pyarrow = ">=14.0.1,<19.0.0"
 pyyaml = "^6.0.2"
 
 [tool.poetry.group.dev]


### PR DESCRIPTION
This change updates the pyarrow dependency from ^14.0.1 to >=14.0.1,<19.0.0 across the main package and affected extensions, allowing users to upgrade to newer pyarrow versions (including 18.1) while maintaining backward compatibility with the current minimum version.

🤖 Generated with [Claude Code](https://claude.ai/code)

- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Relax `pyarrow` dependency constraint to `>=14.0.1,<19.0.0` in three `pyproject.toml` files.
> 
>   - **Dependency Update**:
>     - Relax `pyarrow` version constraint from `^14.0.1` to `>=14.0.1,<19.0.0` in `pyproject.toml`, `extensions/connectors/yfinance/pyproject.toml`, and `extensions/ee/connectors/databricks/pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for f140566f2ca7311acf0d94d2038e79293a6ee239. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->